### PR TITLE
[Fixed] Minor bugs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,29 @@ func highCPUUsage() {
 ```
 
 For more detailed usage instructions, refer to the documentation.
-By default, the dashboard will be available at `http://localhost:8080/`.
+By default, the dashboard will be available at `http://localhost:8080/` else at the port you have provided.
+
+### Note:
+
+The `monigo.TraceFunction(func())` method accept `func(){}` as a type.
+
+### Example Usage:
+
+```go
+func apiHandler(w http.ResponseWriter, r *http.Request) {
+    // Trace function: when the highMemoryUsage function is called, it will be traced.
+    monigo.TraceFunction(highMemoryUsage)
+    w.Write([]byte("API1 response: memexpensiveFunc"))
+}
+
+func highMemoryUsage() {
+    // Simulate high memory usage by allocating a large slice
+    largeSlice := make([]float64, 1e8) // 100 million elements
+    for i := 0; i < len(largeSlice); i++ {
+        largeSlice[i] = float64(i)
+    }
+}
+```
 
 ## Bellow Reports are available
 
@@ -171,9 +193,9 @@ We welcome contributions! If you encounter any issues or have suggestions, pleas
 
 For questions or feedback, please open an issue or contact me at `iyashjayesh@gmail.com` or at [LinkedIn](https://www.linkedin.com/in/iyashjayesh/)
 
-<!-- ## Star History
+## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=iyashjayesh/monigo&type=Date)](https://star-history.com/#iyashjayesh/monigo&Date) -->
+[![Star History Chart](https://api.star-history.com/svg?repos=iyashjayesh/monigo&type=Date)](https://star-history.com/#iyashjayesh/monigo&Date)
 
 ## License
 

--- a/monigo.go
+++ b/monigo.go
@@ -58,20 +58,20 @@ type Cache struct {
 // MonigoInstanceConstructor is the constructor for the Monigo struct
 func (m *Monigo) MonigoInstanceConstructor() {
 
-	// Setting default TimeZone if not provided
-	if m.TimeZone == "" {
+	if m.TimeZone == "" { // Setting default TimeZone if not provided
 		m.TimeZone = "Local"
 	}
 
-	// Loading the time zone location
-	location, err := time.LoadLocation(m.TimeZone)
+	location, err := time.LoadLocation(m.TimeZone) // Loading the time zone location
 	if err != nil {
 		log.Println("Error loading timezone. Setting to Local, Error: ", err)
 		location = time.Local
 	}
 
-	// Setting default values
-	m.DashboardPort = 8080
+	if m.DashboardPort == 0 {
+		// Setting default values in case the dashboard port is not provided
+		m.DashboardPort = 8080
+	}
 	m.DataPointsSyncFrequency = common.DefaultIfEmpty(m.DataPointsSyncFrequency, "5m")
 	m.DataRetentionPeriod = common.DefaultIfEmpty(m.DataRetentionPeriod, "7d")
 	m.MaxCPUUsage = common.DefaultFloatIfZero(m.MaxCPUUsage, 95)

--- a/timeseries/mongiodb.go
+++ b/timeseries/mongiodb.go
@@ -87,7 +87,7 @@ func CloseStorage() {
 		}
 		if storage != nil {
 			if err := storage.Close(); err != nil {
-				log.Panic("Error closing storage: %v\n", err)
+				log.Panicf("Error closing storage: %v\n", err)
 			}
 		}
 	})
@@ -97,9 +97,6 @@ func CloseStorage() {
 func PurgeStorage() {
 	basePath := common.GetBasePath()
 	if err := os.RemoveAll(basePath); err != nil {
-		log.Panicf("Error purging storage: %v\n", err)
-	}
-	if err := os.RemoveAll("./data"); err != nil {
 		log.Panicf("Error purging storage: %v\n", err)
 	}
 }


### PR DESCRIPTION
#### Status: testing 

## Update on Code Changes

After reviewing the feedback, it seems the default port change was missed during the code merge. Additionally, a minor enhancement has been added to the function trace logic.

### Note:
The `monigo.TraceFunction(func())` method accept `func(){}` as a type. 

### Example Usage:
```go
func apiHandler(w http.ResponseWriter, r *http.Request) {
    // Trace function: when the highMemoryUsage function is called, it will be traced.
    monigo.TraceFunction(highMemoryUsage) 
    w.Write([]byte("API1 response: memexpensiveFunc"))
}

func highMemoryUsage() {
    // Simulate high memory usage by allocating a large slice
    largeSlice := make([]float64, 1e8) // 100 million elements
    for i := 0; i < len(largeSlice); i++ {
        largeSlice[i] = float64(i)
    }
}
```