### PR TITLE
docs: remove duplicate main declaration function

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,6 @@ import (
 )
 
 func main() {
-
-func main() {
     // New way: Use Builder Pattern for clean initialization
     monigoInstance := monigo.NewBuilder().
         WithServiceName("data-api").


### PR DESCRIPTION
remvove duplicate `func main()` in the README.md