### PR TITLE
fix: harden runtime internals against wrong scores, leaks, and injection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ profiles/
 
 .DS_Store
 .idea/
+.gocache/
+.gopath/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+- `BasicAuthMiddleware` and `APIKeyMiddleware` now compare credentials with `crypto/subtle.ConstantTimeCompare` -- `!=` short-circuits on the first differing byte and leaks length and prefix information to a timing oracle
+- `ViewFunctionMetrics` validates the function name and report type before invoking `go tool pprof` -- a name beginning with `-` was interpreted as a flag by pprof, and the report type was interpolated straight into the argument list
+- `BasicAuthMiddleware` now sends a `WWW-Authenticate` challenge when a request carries no credentials at all
+
+### Fixed
+- **Inverted health score**: `calculateServiceHealth` clamped the score to `100` -- the best possible value -- when usage exceeded every threshold, so a fully degraded service reported as healthy. It now returns `0`, matching `calculateSystemHealth`
+- **Unbounded memory growth**: `InMemoryStorage.InsertRows` ignored the retention period and never evicted, so `WithStorageType("memory")` grew for the life of the process
+- **`WithStorageType` had no effect**: the storage singleton was initialised by `SetDataPointsSyncFrequency` before `SetStorageType` was applied, so `"memory"` silently fell through to disk
+- **Data race** on `serviceHealthThresholds` between `ConfigureServiceThresholds` and the metrics collection goroutine
+- **Panic** in `common.ConvertToMB` on memory strings shorter than three characters, reachable from health calculation; `calculateMemoryUsagePercentage` also guards against a zero total
+- **Panic** in `TraceFunctionWithArgs` / `TraceFunctionWithReturns` when passed a `nil` argument -- `reflect.ValueOf(nil).Type()` panics. Nillable parameter kinds now accept `nil` as the zero value
+- `CloseStorage()` was permanently terminal via `sync.Once`; a subsequent `GetStorageInstance()` returned the closed handle instead of re-initialising
+- Goroutine leak: each call to `SetDataPointsSyncFrequency` started a ticker goroutine without stopping the previous one
+- Goroutine leak: `RateLimitMiddleware`'s cleanup goroutine is now stopped by `Shutdown()`, not only by the caller invoking the returned `stop`
+- File descriptor leak in `WriteHeapProfile`; nil check in `StopCPUProfile`
+- `registry.GetAll()` documented a snapshot copy but shared the `Labels` map with the live registry
+
+### Added
+- `core.GetThresholds()` -- thread-safe accessor for the configured health thresholds
+- `Build()` validates `MaxCPUUsage` and `MaxMemoryUsage` are within 0-100 and `MaxGoRoutines` is non-negative
+- Regression tests for every fix above
+
+### Changed
+- `monigo.gif` re-encoded from 65 MB to 24 MB -- the module zip is downloaded on every `go get`
+- Argument marshalling shared between `TraceFunctionWithArgs` and `TraceFunctionWithReturns` instead of duplicated
+
 ## [2.0.0] - 2026-02-10
 
 ### Breaking Changes

--- a/common/common.go
+++ b/common/common.go
@@ -325,6 +325,9 @@ func DefaultIntIfZero(val, def int) int {
 func ConvertToMB(value string) (float64, error) {
 	value = strings.TrimSpace(value)
 	value = strings.Replace(value, " ", "", -1)
+	if len(value) < 3 {
+		return 0, fmt.Errorf("invalid memory value: %q", value)
+	}
 	unit := strings.ToUpper(value[len(value)-2:])
 	val, err := strconv.ParseFloat(value[:len(value)-2], 64)
 	if err != nil {

--- a/config_builder.go
+++ b/config_builder.go
@@ -148,5 +148,14 @@ func (b *MonigoBuilder) Build() *Monigo {
 	if b.config.StorageType != "" && b.config.StorageType != "disk" && b.config.StorageType != "memory" {
 		panic("[MoniGo] Build() failed: StorageType must be 'disk' or 'memory'")
 	}
+	if b.config.MaxCPUUsage < 0 || b.config.MaxCPUUsage > 100 {
+		panic("[MoniGo] Build() failed: MaxCPUUsage must be between 0 and 100")
+	}
+	if b.config.MaxMemoryUsage < 0 || b.config.MaxMemoryUsage > 100 {
+		panic("[MoniGo] Build() failed: MaxMemoryUsage must be between 0 and 100")
+	}
+	if b.config.MaxGoRoutines < 0 {
+		panic("[MoniGo] Build() failed: MaxGoRoutines must be >= 0")
+	}
 	return b.config
 }

--- a/config_builder_test.go
+++ b/config_builder_test.go
@@ -93,3 +93,36 @@ func TestBuilderAllOptions(t *testing.T) {
 		t.Errorf("expected '/custom/api', got %q", m.CustomBaseAPIPath)
 	}
 }
+
+func TestBuilderThresholdBounds(t *testing.T) {
+	tests := []struct {
+		name      string
+		configure func(*MonigoBuilder) *MonigoBuilder
+		wantPanic bool
+	}{
+		{"negative CPU", func(b *MonigoBuilder) *MonigoBuilder { return b.WithMaxCPUUsage(-1) }, true},
+		{"CPU above 100", func(b *MonigoBuilder) *MonigoBuilder { return b.WithMaxCPUUsage(101) }, true},
+		{"CPU at 100", func(b *MonigoBuilder) *MonigoBuilder { return b.WithMaxCPUUsage(100) }, false},
+		{"negative memory", func(b *MonigoBuilder) *MonigoBuilder { return b.WithMaxMemoryUsage(-0.5) }, true},
+		{"memory above 100", func(b *MonigoBuilder) *MonigoBuilder { return b.WithMaxMemoryUsage(150) }, true},
+		{"memory at 0", func(b *MonigoBuilder) *MonigoBuilder { return b.WithMaxMemoryUsage(0) }, false},
+		{"negative goroutines", func(b *MonigoBuilder) *MonigoBuilder { return b.WithMaxGoRoutines(-1) }, true},
+		{"goroutines at 0", func(b *MonigoBuilder) *MonigoBuilder { return b.WithMaxGoRoutines(0) }, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				r := recover()
+				if tt.wantPanic && r == nil {
+					t.Error("expected Build() to panic")
+				}
+				if !tt.wantPanic && r != nil {
+					t.Errorf("expected Build() to succeed, panicked with: %v", r)
+				}
+			}()
+
+			tt.configure(NewBuilder().WithServiceName("test")).Build()
+		})
+	}
+}

--- a/core/function-metrics.go
+++ b/core/function-metrics.go
@@ -60,6 +60,36 @@ func FunctionTraceDetails() map[string]*models.FunctionMetrics {
 	return result
 }
 
+func buildArgValues(fnType reflect.Type, args []interface{}) ([]reflect.Value, bool) {
+	if len(args) != fnType.NumIn() {
+		logger.Log.Error("function argument count mismatch", "expected", fnType.NumIn(), "got", len(args))
+		return nil, false
+	}
+
+	argValues := make([]reflect.Value, len(args))
+	for i, arg := range args {
+		expectedType := fnType.In(i)
+		if arg == nil {
+			switch expectedType.Kind() {
+			case reflect.Interface, reflect.Ptr, reflect.Slice, reflect.Map, reflect.Chan, reflect.Func:
+				argValues[i] = reflect.Zero(expectedType)
+			default:
+				logger.Log.Error("argument type mismatch: cannot assign nil to non-nullable type", "index", i, "expected", expectedType)
+				return nil, false
+			}
+			continue
+		}
+
+		argValue := reflect.ValueOf(arg)
+		if !argValue.Type().AssignableTo(expectedType) {
+			logger.Log.Error("argument type mismatch", "index", i, "expected", expectedType, "got", argValue.Type())
+			return nil, false
+		}
+		argValues[i] = argValue
+	}
+	return argValues, true
+}
+
 // TraceFunctionWithArgs traces a function with parameters and captures the metrics
 func TraceFunctionWithArgs(_ context.Context, f interface{}, args ...interface{}) {
 	fnValue := reflect.ValueOf(f)
@@ -69,22 +99,9 @@ func TraceFunctionWithArgs(_ context.Context, f interface{}, args ...interface{}
 	}
 
 	fnType := fnValue.Type()
-
-	if len(args) != fnType.NumIn() {
-		logger.Log.Error("function argument count mismatch", "expected", fnType.NumIn(), "got", len(args))
+	argValues, ok := buildArgValues(fnType, args)
+	if !ok {
 		return
-	}
-
-	argValues := make([]reflect.Value, len(args))
-	for i, arg := range args {
-		argValue := reflect.ValueOf(arg)
-		expectedType := fnType.In(i)
-
-		if !argValue.Type().AssignableTo(expectedType) {
-			logger.Log.Error("argument type mismatch", "index", i, "expected", expectedType, "got", argValue.Type())
-			return
-		}
-		argValues[i] = argValue
 	}
 
 	name := generateFunctionName(fnValue, fnType)
@@ -112,22 +129,9 @@ func TraceFunctionWithReturns(_ context.Context, f interface{}, args ...interfac
 	}
 
 	fnType := fnValue.Type()
-
-	if len(args) != fnType.NumIn() {
-		logger.Log.Error("function argument count mismatch", "expected", fnType.NumIn(), "got", len(args))
+	argValues, ok := buildArgValues(fnType, args)
+	if !ok {
 		return nil
-	}
-
-	argValues := make([]reflect.Value, len(args))
-	for i, arg := range args {
-		argValue := reflect.ValueOf(arg)
-		expectedType := fnType.In(i)
-
-		if !argValue.Type().AssignableTo(expectedType) {
-			logger.Log.Error("argument type mismatch", "index", i, "expected", expectedType, "got", argValue.Type())
-			return nil
-		}
-		argValues[i] = argValue
 	}
 
 	name := generateFunctionName(fnValue, fnType)
@@ -291,9 +295,18 @@ func ViewFunctionMetrics(name, reportType string, metrics *models.FunctionMetric
 		}
 	}
 
+	// Validate function name to ensure it doesn't look like a flag or contain shell control characters
+	isNameInvalid := strings.HasPrefix(name, "-") || strings.ContainsAny(name, ";&|$` \t\n")
+
 	executePprof := func(profileFilePath, reportType string) string {
+		if isNameInvalid {
+			return "Error: Invalid function name"
+		}
 		if profileFilePath == "" {
 			return "Error: Profile file path is empty"
+		}
+		if reportType != "text" && reportType != "traces" && reportType != "tree" {
+			return "Error: Invalid report type"
 		}
 		cmd := exec.Command("go", "tool", "pprof", "-"+reportType, profileFilePath)
 		output, err := cmd.CombinedOutput()
@@ -304,7 +317,9 @@ func ViewFunctionMetrics(name, reportType string, metrics *models.FunctionMetric
 	}
 
 	var codeStack string
-	if metrics.CPUProfileFilePath != "" {
+	if isNameInvalid {
+		codeStack = "Error: Invalid function name"
+	} else if metrics.CPUProfileFilePath != "" {
 		codeStackView := exec.Command("go", "tool", "pprof", "-list", name, metrics.CPUProfileFilePath)
 		output, err := codeStackView.CombinedOutput()
 		if err != nil {

--- a/core/function_metrics_test.go
+++ b/core/function_metrics_test.go
@@ -2,7 +2,10 @@ package core
 
 import (
 	"context"
+	"strings"
 	"testing"
+
+	"github.com/iyashjayesh/monigo/models"
 )
 
 func TestTraceFunction(t *testing.T) {
@@ -107,5 +110,133 @@ func TestFunctionTraceDetailsReturnsCopy(t *testing.T) {
 
 	if len(details2) == 0 {
 		t.Error("expected FunctionTraceDetails to return independent copies")
+	}
+}
+
+// ViewFunctionMetrics shells out to `go tool pprof` with a caller-supplied
+// function name and report type. A name beginning with "-" is interpreted as a
+// flag by pprof, and the report type is interpolated straight into the argument
+// list, so both must be rejected before the exec.
+func TestViewFunctionMetricsRejectsUnsafeArguments(t *testing.T) {
+	metrics := &models.FunctionMetrics{
+		CPUProfileFilePath: "testdata/does-not-exist.prof",
+		MemProfileFilePath: "testdata/does-not-exist.prof",
+	}
+
+	unsafeNames := []string{
+		"-output=/tmp/pwned",
+		"-http=:8080",
+		"name; rm -rf /",
+		"name && whoami",
+		"name | cat",
+		"name $(id)",
+		"name `id`",
+		"name\nwhoami",
+	}
+
+	for _, name := range unsafeNames {
+		got := ViewFunctionMetrics(name, "text", metrics)
+		if !strings.Contains(got.FunctionCodeTrace, "Invalid function name") {
+			t.Errorf("name %q: expected the code trace to be rejected, got %q", name, got.FunctionCodeTrace)
+		}
+		if !strings.Contains(got.CoreProfile.CPU, "Invalid function name") {
+			t.Errorf("name %q: expected the CPU profile to be rejected, got %q", name, got.CoreProfile.CPU)
+		}
+	}
+}
+
+func TestViewFunctionMetricsRejectsUnknownReportType(t *testing.T) {
+	metrics := &models.FunctionMetrics{
+		CPUProfileFilePath: "testdata/does-not-exist.prof",
+		MemProfileFilePath: "testdata/does-not-exist.prof",
+	}
+
+	for _, reportType := range []string{"", "svg", "-http=:8080", "web"} {
+		got := ViewFunctionMetrics("SafeName", reportType, metrics)
+		if !strings.Contains(got.CoreProfile.CPU, "Invalid report type") {
+			t.Errorf("reportType %q: expected rejection, got %q", reportType, got.CoreProfile.CPU)
+		}
+	}
+}
+
+func TestViewFunctionMetricsAcceptsSafeArguments(t *testing.T) {
+	metrics := &models.FunctionMetrics{
+		CPUProfileFilePath: "testdata/does-not-exist.prof",
+		MemProfileFilePath: "testdata/does-not-exist.prof",
+	}
+
+	for _, reportType := range []string{"text", "traces", "tree"} {
+		got := ViewFunctionMetrics("main.SafeName", reportType, metrics)
+		if strings.Contains(got.CoreProfile.CPU, "Invalid report type") {
+			t.Errorf("reportType %q was rejected but should be allowed", reportType)
+		}
+		if strings.Contains(got.CoreProfile.CPU, "Invalid function name") {
+			t.Errorf("reportType %q: safe name was rejected", reportType)
+		}
+	}
+}
+
+// A nil argument used to panic: reflect.ValueOf(nil) yields an invalid Value and
+// calling .Type() on it panics. Nillable parameter kinds must accept nil as the
+// zero value; non-nillable kinds must be rejected with a log, not a panic.
+func TestTraceFunctionWithArgs_NilArguments(t *testing.T) {
+	SetSamplingRate(1)
+
+	t.Run("nil into a pointer parameter", func(t *testing.T) {
+		got := "not called"
+		TraceFunctionWithArgs(context.Background(), func(p *int) {
+			if p == nil {
+				got = "nil"
+			}
+		}, nil)
+		if got != "nil" {
+			t.Errorf("expected the function to run with a nil pointer, got %q", got)
+		}
+	})
+
+	t.Run("nil into an interface parameter", func(t *testing.T) {
+		called := false
+		TraceFunctionWithArgs(context.Background(), func(v interface{}) {
+			called = true
+		}, nil)
+		if !called {
+			t.Error("expected the function to run with a nil interface")
+		}
+	})
+
+	t.Run("nil into a slice and map parameter", func(t *testing.T) {
+		called := false
+		TraceFunctionWithArgs(context.Background(), func(s []string, m map[string]int) {
+			called = s == nil && m == nil
+		}, nil, nil)
+		if !called {
+			t.Error("expected the function to run with nil slice and map")
+		}
+	})
+
+	t.Run("nil into a non-nillable parameter is rejected", func(t *testing.T) {
+		called := false
+		TraceFunctionWithArgs(context.Background(), func(n int) { called = true }, nil)
+		if called {
+			t.Error("expected nil to be rejected for an int parameter")
+		}
+	})
+}
+
+func TestTraceFunctionWithReturns_NilArguments(t *testing.T) {
+	SetSamplingRate(1)
+
+	results := TraceFunctionWithReturns(context.Background(), func(p *int) string {
+		if p == nil {
+			return "nil"
+		}
+		return "non-nil"
+	}, nil)
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 return value, got %d", len(results))
+	}
+	if results[0] != "nil" {
+		t.Errorf("expected %q, got %v", "nil", results[0])
 	}
 }

--- a/core/health-check.go
+++ b/core/health-check.go
@@ -28,6 +28,9 @@ func calculateMemoryUsagePercentage(usedMemory, totalMemory string) (float64, er
 	if err != nil {
 		return 0, err
 	}
+	if totalMemoryMB == 0 {
+		return 0, fmt.Errorf("total memory is zero, cannot calculate usage percentage")
+	}
 	return (usedMemoryMB / totalMemoryMB) * 100, nil
 }
 
@@ -51,31 +54,33 @@ func calculateServiceHealth(stats *models.ServiceStats) (float64, string, error)
 	}
 
 	// Calculating the health ratios for CPU, memory, and goroutines
-	cpuUsageRatio := (cpuUsagePercentage / serviceHealthThresholds.MaxCPUUsage) * 100
-	memoryUsageRatio := (memoryUsagePercentage / serviceHealthThresholds.MaxMemoryUsage) * 100
-	goRoutinesRatio := (float64(getServiceGoroutines()) / float64(serviceHealthThresholds.MaxGoRoutines)) * 100
+	t := GetThresholds()
+	cpuUsageRatio := (cpuUsagePercentage / t.MaxCPUUsage) * 100
+	memoryUsageRatio := (memoryUsagePercentage / t.MaxMemoryUsage) * 100
+	goRoutinesRatio := (float64(getServiceGoroutines()) / float64(t.MaxGoRoutines)) * 100
 	finalScore := (cpuUsageRatio + memoryUsageRatio + goRoutinesRatio) / 3
 
+	var healthScore float64
 	var message string
 	if finalScore > 100 {
-		finalScore = 100
+		healthScore = 0
 		message = fmt.Sprintf(
 			"Service usage exceeds allowed limits: CPU Usage %.2f%% / %.2f%%, Memory Usage %.2f%% / %.2f%%, Goroutines %.2f / %d",
-			cpuUsageRatio, serviceHealthThresholds.MaxCPUUsage,
-			memoryUsageRatio, serviceHealthThresholds.MaxMemoryUsage,
-			goRoutinesRatio, serviceHealthThresholds.MaxGoRoutines,
+			cpuUsageRatio, t.MaxCPUUsage,
+			memoryUsageRatio, t.MaxMemoryUsage,
+			goRoutinesRatio, t.MaxGoRoutines,
 		)
 	} else {
-		finalScore = 100 - finalScore
+		healthScore = 100 - finalScore
 		message = fmt.Sprintf(
 			"Service usage is within limits: CPU Usage %.2f%% / %.2f%%, Memory Usage %.2f%% / %.2f%%, Goroutines %.2f / %d",
-			cpuUsageRatio, serviceHealthThresholds.MaxCPUUsage,
-			memoryUsageRatio, serviceHealthThresholds.MaxMemoryUsage,
-			goRoutinesRatio, serviceHealthThresholds.MaxGoRoutines,
+			cpuUsageRatio, t.MaxCPUUsage,
+			memoryUsageRatio, t.MaxMemoryUsage,
+			goRoutinesRatio, t.MaxGoRoutines,
 		)
 	}
 
-	return finalScore, message, nil
+	return healthScore, message, nil
 }
 
 // calculateSystemHealth calculates system health based on CPU and memory
@@ -94,27 +99,30 @@ func calculateSystemHealth(stats *models.ServiceStats) (float64, string, error) 
 		return 0, "", fmt.Errorf("failed to calculate memory usage percentage: %w", err)
 	}
 
-	cpuUsageRatio := (cpuUsagePercentage / serviceHealthThresholds.MaxCPUUsage) * 100
-	memoryUsageRatio := (memoryUsagePercentage / serviceHealthThresholds.MaxMemoryUsage) * 100
+	t := GetThresholds()
+	cpuUsageRatio := (cpuUsagePercentage / t.MaxCPUUsage) * 100
+	memoryUsageRatio := (memoryUsagePercentage / t.MaxMemoryUsage) * 100
 	finalScore := (cpuUsageRatio + memoryUsageRatio) / 2
+
+	var healthScore float64
 	var message string
 	if finalScore > 100 {
-		finalScore = 0
+		healthScore = 0
 		message = fmt.Sprintf(
 			"System usage exceeds allowed limits: CPU Usage %.2f%% / %.2f%%, Memory Usage %.2f%% / %.2f%%",
-			cpuUsageRatio, serviceHealthThresholds.MaxCPUUsage,
-			memoryUsageRatio, serviceHealthThresholds.MaxMemoryUsage,
+			cpuUsageRatio, t.MaxCPUUsage,
+			memoryUsageRatio, t.MaxMemoryUsage,
 		)
 	} else {
-		finalScore = 100 - finalScore
+		healthScore = 100 - finalScore
 		message = fmt.Sprintf(
 			"System usage is within limits: CPU Usage %.2f%% / %.2f%%, Memory Usage %.2f%% / %.2f%%",
-			cpuUsageRatio, serviceHealthThresholds.MaxCPUUsage,
-			memoryUsageRatio, serviceHealthThresholds.MaxMemoryUsage,
+			cpuUsageRatio, t.MaxCPUUsage,
+			memoryUsageRatio, t.MaxMemoryUsage,
 		)
 	}
 
-	return finalScore, message, nil
+	return healthScore, message, nil
 }
 
 // CalculateHealthScore calculates the health score of both the system and service
@@ -125,21 +133,22 @@ func CalculateHealthScore(serviceStats *models.ServiceStats) (*models.SystemHeal
 		return nil, fmt.Errorf("failed to calculate system health: %w", err)
 	}
 
-	// CalcCalculating service health
+	// Calculating service health
 	serviceScore, serviceMsg, err := calculateServiceHealth(serviceStats)
 	if err != nil {
 		return nil, fmt.Errorf("failed to calculate service health: %w", err)
 	}
 
+	t := GetThresholds()
 	return &models.SystemHealthInPercent{
 		SystemHealth: models.HealthFields{
 			Percentage:    common.RoundFloat64(systemScore, 2),
-			AllowedByUser: serviceHealthThresholds.MaxCPUUsage,
+			AllowedByUser: t.MaxCPUUsage,
 			Message:       systemMsg,
 		},
 		ServiceHealth: models.HealthFields{
 			Percentage:    common.RoundFloat64(serviceScore, 2),
-			AllowedByUser: serviceHealthThresholds.MaxCPUUsage,
+			AllowedByUser: t.MaxCPUUsage,
 			Message:       serviceMsg,
 		},
 	}, nil

--- a/core/health_check_test.go
+++ b/core/health_check_test.go
@@ -1,0 +1,161 @@
+package core
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/iyashjayesh/monigo/models"
+)
+
+// breachStats returns a ServiceStats that, combined with the near-zero thresholds
+// the breach tests configure, pushes every usage ratio past 100% regardless of
+// what the host process is actually doing.
+func breachStats() *models.ServiceStats {
+	stats := &models.ServiceStats{}
+	stats.CPUStatistics.TotalCores = 1
+	stats.MemoryStatistics.TotalSystemMemory = "100 MB"
+	stats.MemoryStatistics.MemoryUsedByService = "99 MB"
+	stats.MemoryStatistics.MemoryUsedBySystem = "99 MB"
+	return stats
+}
+
+// healthyStats returns a ServiceStats whose denominators are large enough that
+// the live process CPU reading cannot dominate the score. Service CPU usage is
+// divided by TotalCores, so a small core count makes the result depend on how
+// busy the machine running the tests happens to be.
+func healthyStats() *models.ServiceStats {
+	stats := &models.ServiceStats{}
+	stats.CPUStatistics.TotalCores = 100000
+	stats.MemoryStatistics.TotalSystemMemory = "100000 MB"
+	stats.MemoryStatistics.MemoryUsedByService = "1 MB"
+	stats.MemoryStatistics.MemoryUsedBySystem = "1 MB"
+	return stats
+}
+
+// withThresholds swaps in thresholds for the duration of fn and restores the
+// originals afterwards, so tests do not leak configuration into one another.
+func withThresholds(t *testing.T, th models.ServiceHealthThresholds, fn func()) {
+	t.Helper()
+	original := GetThresholds()
+	ConfigureServiceThresholds(&th)
+	defer ConfigureServiceThresholds(&original)
+	fn()
+}
+
+// A service over every threshold must score 0, not 100. The breach branch used to
+// clamp the score to 100 -- the best possible value -- so a service exceeding all
+// of its limits reported as perfectly healthy.
+func TestCalculateServiceHealthScoresZeroOnBreach(t *testing.T) {
+	withThresholds(t, models.ServiceHealthThresholds{
+		MaxCPUUsage:    0.0001,
+		MaxMemoryUsage: 0.0001,
+		MaxGoRoutines:  1,
+	}, func() {
+		score, msg, err := calculateServiceHealth(breachStats())
+		if err != nil {
+			t.Fatalf("calculateServiceHealth returned error: %v", err)
+		}
+		if score != 0 {
+			t.Errorf("expected score 0 when usage exceeds all thresholds, got %v", score)
+		}
+		if msg == "" {
+			t.Error("expected a non-empty breach message")
+		}
+	})
+}
+
+// Service and system health must agree on what a breach scores.
+func TestServiceAndSystemHealthAgreeOnBreach(t *testing.T) {
+	withThresholds(t, models.ServiceHealthThresholds{
+		MaxCPUUsage:    0.0001,
+		MaxMemoryUsage: 0.0001,
+		MaxGoRoutines:  1,
+	}, func() {
+		serviceScore, _, err := calculateServiceHealth(breachStats())
+		if err != nil {
+			t.Fatalf("calculateServiceHealth returned error: %v", err)
+		}
+		systemScore, _, err := calculateSystemHealth(breachStats())
+		if err != nil {
+			t.Fatalf("calculateSystemHealth returned error: %v", err)
+		}
+		if serviceScore != systemScore {
+			t.Errorf("service and system health disagree on breach: service=%v system=%v", serviceScore, systemScore)
+		}
+	})
+}
+
+// Usage comfortably inside the thresholds must not report a breach.
+func TestCalculateServiceHealthWithinLimits(t *testing.T) {
+	withThresholds(t, models.ServiceHealthThresholds{
+		MaxCPUUsage:    100,
+		MaxMemoryUsage: 100,
+		MaxGoRoutines:  1000000,
+	}, func() {
+		score, msg, err := calculateServiceHealth(healthyStats())
+		if err != nil {
+			t.Fatalf("calculateServiceHealth returned error: %v", err)
+		}
+		if score <= 0 || score > 100 {
+			t.Errorf("expected a score in (0, 100] when within limits, got %v", score)
+		}
+		if !strings.Contains(msg, "within limits") {
+			t.Errorf("expected a within-limits message, got %q", msg)
+		}
+	})
+}
+
+func TestGetThresholdsReturnsConfiguredValues(t *testing.T) {
+	withThresholds(t, models.ServiceHealthThresholds{
+		MaxCPUUsage:    42,
+		MaxMemoryUsage: 43,
+		MaxGoRoutines:  44,
+	}, func() {
+		got := GetThresholds()
+		if got.MaxCPUUsage != 42 || got.MaxMemoryUsage != 43 || got.MaxGoRoutines != 44 {
+			t.Errorf("GetThresholds returned %+v, want {42 43 44}", got)
+		}
+	})
+}
+
+// Thresholds are written at configuration time and read from the metrics
+// collection goroutine. Run under -race to catch unsynchronised access.
+func TestThresholdsConcurrentAccess(t *testing.T) {
+	original := GetThresholds()
+	defer ConfigureServiceThresholds(&original)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(2)
+		go func(n int) {
+			defer wg.Done()
+			ConfigureServiceThresholds(&models.ServiceHealthThresholds{
+				MaxCPUUsage:    float64(n%100 + 1),
+				MaxMemoryUsage: float64(n%100 + 1),
+				MaxGoRoutines:  n + 1,
+			})
+		}(i)
+		go func() {
+			defer wg.Done()
+			_ = GetThresholds()
+		}()
+	}
+	wg.Wait()
+}
+
+// Malformed memory strings must surface as errors, not panic. A short or empty
+// value used to slice out of range inside common.ConvertToMB.
+func TestCalculateMemoryUsagePercentageMalformedInput(t *testing.T) {
+	for _, tc := range []struct{ used, total string }{
+		{"", "100 MB"},
+		{"M", "100 MB"},
+		{"99 MB", ""},
+		{"99 MB", "0 MB"},
+		{"99 XB", "100 MB"},
+	} {
+		if _, err := calculateMemoryUsagePercentage(tc.used, tc.total); err == nil {
+			t.Errorf("expected error for used=%q total=%q, got nil", tc.used, tc.total)
+		}
+	}
+}

--- a/core/metrics.go
+++ b/core/metrics.go
@@ -15,6 +15,7 @@ import (
 
 var (
 	mu                      sync.Mutex
+	thresholdsMu            sync.RWMutex
 	serviceHealthThresholds models.ServiceHealthThresholds
 )
 
@@ -60,8 +61,17 @@ func getProcessUsage(proc *process.Process, memsStats *mem.VirtualMemoryStat) (f
 	return procCPUPercent, processMemPercent, nil
 }
 
-// SetServiceThresholds sets the service thresholds to calculate the overall service health.
+// GetThresholds returns a copy of the current service health thresholds in a thread-safe manner.
+func GetThresholds() models.ServiceHealthThresholds {
+	thresholdsMu.RLock()
+	defer thresholdsMu.RUnlock()
+	return serviceHealthThresholds
+}
+
+// ConfigureServiceThresholds sets the service thresholds to calculate the overall service health.
 func ConfigureServiceThresholds(thresholdsValues *models.ServiceHealthThresholds) {
+	thresholdsMu.Lock()
+	defer thresholdsMu.Unlock()
 	serviceHealthThresholds = *thresholdsValues
 }
 

--- a/core/profile.go
+++ b/core/profile.go
@@ -22,7 +22,9 @@ func StartCPUProfile(filename string) (*os.File, error) {
 // StopCPUProfile stops the current CPU profile and writes it to the specified file.
 func StopCPUProfile(f *os.File) {
 	pprof.StopCPUProfile()
-	f.Close()
+	if f != nil {
+		f.Close()
+	}
 }
 
 // WriteHeapProfile writes the current memory heap profile to the specified file.
@@ -31,6 +33,7 @@ func WriteHeapProfile(filename string) error {
 	if err != nil {
 		return err
 	}
+	defer f.Close()
 	runtime.GC() // Get up-to-date statistics
 	return pprof.WriteHeapProfile(f)
 }

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -76,7 +76,7 @@ func (r *Registry) RecordHistogram(name string, value float64, labels map[string
 	}
 }
 
-// GetAll returns a snapshot copy of all metrics.
+// GetAll returns a snapshot copy of all metrics with deep-copied label maps.
 func (r *Registry) GetAll() []*MetricValue {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -84,6 +84,12 @@ func (r *Registry) GetAll() []*MetricValue {
 	values := make([]*MetricValue, 0, len(r.metrics))
 	for _, v := range r.metrics {
 		cp := *v
+		if v.Labels != nil {
+			cp.Labels = make(map[string]string, len(v.Labels))
+			for k, val := range v.Labels {
+				cp.Labels[k] = val
+			}
+		}
 		values = append(values, &cp)
 	}
 	return values

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -84,14 +84,18 @@ func TestDelete(t *testing.T) {
 
 func TestGetAllReturnsSnapshot(t *testing.T) {
 	r := NewRegistry()
-	r.SetGauge("cpu", 42, nil)
+	r.SetGauge("cpu", 42, map[string]string{"host": "localhost"})
 
 	metrics := r.GetAll()
 	metrics[0].Value = 999
+	metrics[0].Labels["host"] = "modified"
 
 	fresh := r.GetAll()
 	if fresh[0].Value != 42 {
 		t.Errorf("GetAll should return a copy; original was modified")
+	}
+	if fresh[0].Labels["host"] != "localhost" {
+		t.Errorf("GetAll should return a deep copy of labels map; original labels map was modified")
 	}
 }
 

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -1,8 +1,10 @@
 package monigo
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"testing"
 	"time"
 )
@@ -249,4 +251,100 @@ func TestCustomAuthFunction(t *testing.T) {
 	if w.Code != http.StatusUnauthorized {
 		t.Errorf("Expected status 401, got %d", w.Code)
 	}
+}
+
+// Credential comparison must be constant-time and must not accept a partial
+// match. These cases previously ran through `!=`, which short-circuits on the
+// first differing byte and leaks length and prefix information.
+func TestBasicAuthMiddlewareRejectsPartialMatches(t *testing.T) {
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := BasicAuthMiddleware("admin", "password")(testHandler)
+
+	cases := []struct{ user, pass string }{
+		{"admin", "passwor"},   // prefix of the password
+		{"admin", "passwords"}, // password plus a byte
+		{"admi", "password"},   // prefix of the username
+		{"admins", "password"}, // username plus a byte
+		{"", ""},
+		{"admin", ""},
+		{"", "password"},
+		{"password", "admin"}, // swapped
+	}
+
+	for _, tc := range cases {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.SetBasicAuth(tc.user, tc.pass)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("user=%q pass=%q: expected 401, got %d", tc.user, tc.pass, w.Code)
+		}
+	}
+}
+
+// A request carrying no credentials at all must still be challenged, so clients
+// know to retry with credentials rather than treating the 401 as terminal.
+func TestBasicAuthMiddlewareChallengesMissingCredentials(t *testing.T) {
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := BasicAuthMiddleware("admin", "password")(testHandler)
+
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", w.Code)
+	}
+	if got := w.Header().Get("WWW-Authenticate"); got == "" {
+		t.Error("expected a WWW-Authenticate challenge header on a credential-less request")
+	}
+}
+
+func TestAPIKeyMiddlewareRejectsPartialMatches(t *testing.T) {
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := APIKeyMiddleware("secret-key")(testHandler)
+
+	for _, key := range []string{"", "secret-ke", "secret-keys", "s", "SECRET-KEY"} {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("X-API-Key", key)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("key=%q: expected 401, got %d", key, w.Code)
+		}
+	}
+}
+
+// RateLimitMiddleware spawns a cleanup goroutine. Shutdown must stop it even
+// when the caller never invokes the returned stop function.
+func TestShutdownStopsRateLimiterCleanup(t *testing.T) {
+	before := runtime.NumGoroutine()
+
+	for i := 0; i < 5; i++ {
+		_, _ = RateLimitMiddleware(10, 10*time.Millisecond)
+	}
+
+	m := &Monigo{ServiceName: "test-service"}
+	if err := m.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown returned error: %v", err)
+	}
+
+	// Give the stopped goroutines a moment to unwind.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if runtime.NumGoroutine() <= before+1 {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Errorf("rate limiter cleanup goroutines still running after Shutdown: before=%d after=%d",
+		before, runtime.NumGoroutine())
 }

--- a/monigo.go
+++ b/monigo.go
@@ -2,6 +2,7 @@ package monigo
 
 import (
 	"context"
+	"crypto/subtle"
 	"embed"
 	"errors"
 	"fmt"
@@ -181,8 +182,12 @@ func (m *Monigo) setup() error {
 		return fmt.Errorf("[MoniGo] service_name is required, please provide the service name")
 	}
 
+	if m.StorageType != "" {
+		timeseries.SetStorageType(m.StorageType)
+	}
+
 	if err := timeseries.SetDataPointsSyncFrequency(m.DataPointsSyncFrequency); err != nil {
-		return fmt.Errorf("[MoniGo] failed to set data points sync frequency: %v", err)
+		return fmt.Errorf("[MoniGo] failed to set data points sync frequency: %w", err)
 	}
 
 	m.ProcessId = common.GetProcessId()
@@ -213,9 +218,6 @@ func (m *Monigo) setup() error {
 		m.DataRetentionPeriod,
 	)
 
-	if m.StorageType != "" {
-		timeseries.SetStorageType(m.StorageType)
-	}
 	if m.SamplingRate > 0 {
 		core.SetSamplingRate(m.SamplingRate)
 	}
@@ -246,6 +248,7 @@ func (m *Monigo) setup() error {
 // Shutdown performs a graceful cleanup of resources (OTel provider, storage, etc.).
 func (m *Monigo) Shutdown(ctx context.Context) error {
 	var errs []error
+	runCleanups()
 	if m.otelExporter != nil {
 		if err := m.otelExporter.Shutdown(ctx); err != nil {
 			errs = append(errs, fmt.Errorf("otel shutdown: %w", err))
@@ -740,7 +743,14 @@ func BasicAuthMiddleware(username, password string) func(http.Handler) http.Hand
 				return
 			}
 			user, pass, ok := r.BasicAuth()
-			if !ok || user != username || pass != password {
+			if !ok {
+				w.Header().Set("WWW-Authenticate", `Basic realm="MoniGo Dashboard"`)
+				http.Error(w, "Unauthorized", http.StatusUnauthorized)
+				return
+			}
+			userMatch := subtle.ConstantTimeCompare([]byte(user), []byte(username)) == 1
+			passMatch := subtle.ConstantTimeCompare([]byte(pass), []byte(password)) == 1
+			if !userMatch || !passMatch {
 				w.Header().Set("WWW-Authenticate", `Basic realm="MoniGo Dashboard"`)
 				http.Error(w, "Unauthorized", http.StatusUnauthorized)
 				return
@@ -762,7 +772,7 @@ func APIKeyMiddleware(apiKey string) func(http.Handler) http.Handler {
 			if providedKey == "" {
 				providedKey = r.URL.Query().Get("api_key")
 			}
-			if providedKey != apiKey {
+			if subtle.ConstantTimeCompare([]byte(providedKey), []byte(apiKey)) != 1 {
 				http.Error(w, "Unauthorized", http.StatusUnauthorized)
 				return
 			}
@@ -789,6 +799,28 @@ func IPWhitelistMiddleware(allowedIPs []string) func(http.Handler) http.Handler 
 			http.Error(w, "Forbidden", http.StatusForbidden)
 		})
 	}
+}
+
+var (
+	activeCleanups   []func()
+	activeCleanupsMu sync.Mutex
+)
+
+func registerCleanup(f func()) {
+	activeCleanupsMu.Lock()
+	defer activeCleanupsMu.Unlock()
+	activeCleanups = append(activeCleanups, f)
+}
+
+func runCleanups() {
+	activeCleanupsMu.Lock()
+	defer activeCleanupsMu.Unlock()
+	for _, f := range activeCleanups {
+		if f != nil {
+			f()
+		}
+	}
+	activeCleanups = nil
 }
 
 // RateLimitMiddleware creates a simple rate limiting middleware.
@@ -851,6 +883,7 @@ func RateLimitMiddleware(requests int, window time.Duration) (mw func(http.Handl
 	}
 
 	stop = cancel
+	registerCleanup(stop)
 	return
 }
 

--- a/timeseries/monigodb.go
+++ b/timeseries/monigodb.go
@@ -2,7 +2,6 @@ package timeseries
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -38,8 +37,29 @@ func NewInMemoryStorage() *InMemoryStorage {
 func (s *InMemoryStorage) InsertRows(rows []Row) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	retention := common.GetDataRetentionPeriod()
+	cutoff := time.Now().Add(-retention).Unix()
+
 	for _, row := range rows {
-		s.data[row.Metric] = append(s.data[row.Metric], row.DataPoint)
+		if row.DataPoint.Timestamp >= cutoff {
+			s.data[row.Metric] = append(s.data[row.Metric], row.DataPoint)
+		}
+	}
+
+	// Purge expired data points
+	for metric, points := range s.data {
+		var valid []DataPoint
+		for _, p := range points {
+			if p.Timestamp >= cutoff {
+				valid = append(valid, p)
+			}
+		}
+		if len(valid) == 0 {
+			delete(s.data, metric)
+		} else {
+			s.data[metric] = valid
+		}
 	}
 	return nil
 }
@@ -100,12 +120,11 @@ func (s *StorageWrapper) Close() error {
 }
 
 type storageManager struct {
-	storage   Storage
-	ctx       context.Context
-	cancel    context.CancelFunc
-	once      sync.Once
-	closeOnce sync.Once
-	mu        sync.Mutex
+	storage    Storage
+	ctx        context.Context
+	cancel     context.CancelFunc
+	syncCancel context.CancelFunc
+	mu         sync.Mutex
 }
 
 var (
@@ -120,45 +139,56 @@ func SetStorageType(t string) {
 
 // GetStorageInstance initializes and returns a Storage instance.
 func GetStorageInstance() (Storage, error) {
-	var err error
-	manager.once.Do(func() {
-		if storageType == "memory" {
-			manager.storage = NewInMemoryStorage()
-			manager.ctx, manager.cancel = context.WithCancel(context.Background())
-			return
-		}
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
 
-		basePath := common.GetBasePath()
-		storageInstance, initErr := tstorage.NewStorage(
-			tstorage.WithDataPath(filepath.Join(basePath, "data")),
-			tstorage.WithRetention(common.GetDataRetentionPeriod()),
-		)
-		if initErr != nil {
-			err = initErr
-			logger.Log.Error("initializing storage", "error", err)
-			return
-		}
-		manager.storage = &StorageWrapper{storage: storageInstance}
-		// Initialize context and cancel function for goroutines
+	if manager.storage != nil {
+		return manager.storage, nil
+	}
+
+	if storageType == "memory" {
+		manager.storage = NewInMemoryStorage()
 		manager.ctx, manager.cancel = context.WithCancel(context.Background())
-	})
-	return manager.storage, err
+		return manager.storage, nil
+	}
+
+	basePath := common.GetBasePath()
+	storageInstance, initErr := tstorage.NewStorage(
+		tstorage.WithDataPath(filepath.Join(basePath, "data")),
+		tstorage.WithRetention(common.GetDataRetentionPeriod()),
+	)
+	if initErr != nil {
+		logger.Log.Error("initializing storage", "error", initErr)
+		return nil, fmt.Errorf("initializing storage: %w", initErr)
+	}
+	manager.storage = &StorageWrapper{storage: storageInstance}
+	// Initialize context and cancel function for goroutines
+	manager.ctx, manager.cancel = context.WithCancel(context.Background())
+	return manager.storage, nil
 }
 
 // CloseStorage closes the storage instance and stops any running goroutines.
 func CloseStorage() error {
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+
+	if manager.syncCancel != nil {
+		manager.syncCancel()
+		manager.syncCancel = nil
+	}
+	if manager.cancel != nil {
+		manager.cancel()
+		manager.cancel = nil
+	}
+
 	var err error
-	manager.closeOnce.Do(func() {
-		if manager.cancel != nil {
-			manager.cancel() // Stop any goroutines
+	if manager.storage != nil {
+		if closeErr := manager.storage.Close(); closeErr != nil {
+			logger.Log.Error("closing storage", "error", closeErr)
+			err = closeErr
 		}
-		if manager.storage != nil {
-			if closeErr := manager.storage.Close(); closeErr != nil {
-				logger.Log.Error("closing storage", "error", closeErr)
-				err = closeErr
-			}
-		}
-	})
+		manager.storage = nil
+	}
 	return err
 }
 
@@ -206,18 +236,27 @@ func SetDataPointsSyncFrequency(frequency ...string) error {
 	// Initializing service metrics once
 	serviceMetrics := core.GetServiceStats(context.Background())
 	if err := StoreServiceMetrics(&serviceMetrics); err != nil {
-		return errors.New("[MoniGo] error storing service metrics, err: " + err.Error())
+		return fmt.Errorf("[MoniGo] error storing service metrics: %w", err)
 	}
+
+	manager.mu.Lock()
+	if manager.syncCancel != nil {
+		manager.syncCancel()
+	}
+
+	var syncCtx context.Context
+	syncCtx, manager.syncCancel = context.WithCancel(manager.ctx)
+	manager.mu.Unlock()
 
 	ticker := time.NewTicker(freqTime)
 	go func() {
 		defer ticker.Stop()
 		for {
 			select {
-			case <-manager.ctx.Done():
+			case <-syncCtx.Done():
 				return
 			case <-ticker.C:
-				serviceMetrics := core.GetServiceStats(manager.ctx)
+				serviceMetrics := core.GetServiceStats(syncCtx)
 				if err := StoreServiceMetrics(&serviceMetrics); err != nil {
 					logger.Log.Error("storing service metrics", "error", err)
 				}

--- a/timeseries/timeseries_test.go
+++ b/timeseries/timeseries_test.go
@@ -149,3 +149,100 @@ func TestStoreAndRetrieveMetrics(t *testing.T) {
 	// Cleanup
 	CloseStorage()
 }
+
+// The in-memory backend used to append unconditionally and never evict, so
+// WithStorageType("memory") grew without bound for the life of the process.
+// Retention comes from common.GetDataRetentionPeriod(), set to 7d in init().
+func TestInMemoryStorage_EnforcesRetention(t *testing.T) {
+	s := NewInMemoryStorage()
+	retention := common.GetDataRetentionPeriod()
+
+	now := time.Now()
+	fresh := now.Unix()
+	expired := now.Add(-retention - time.Hour).Unix()
+
+	rows := []Row{
+		{Metric: "cpu_load", DataPoint: DataPoint{Timestamp: expired, Value: 1}},
+		{Metric: "cpu_load", DataPoint: DataPoint{Timestamp: fresh, Value: 2}},
+	}
+	if err := s.InsertRows(rows); err != nil {
+		t.Fatalf("InsertRows error: %v", err)
+	}
+
+	points, err := s.Select("cpu_load", nil, 0, fresh+60)
+	if err != nil {
+		t.Fatalf("Select error: %v", err)
+	}
+	if len(points) != 1 {
+		t.Fatalf("expected the expired point to be dropped, got %d points", len(points))
+	}
+	if points[0].Value != 2 {
+		t.Errorf("expected the fresh point to survive, got value %v", points[0].Value)
+	}
+}
+
+// Points already held are purged once they age past the retention window.
+func TestInMemoryStorage_PurgesExpiredOnInsert(t *testing.T) {
+	s := NewInMemoryStorage()
+	retention := common.GetDataRetentionPeriod()
+
+	// Seed a point that is inside the window at insert time.
+	borderline := time.Now().Add(-retention + 2*time.Hour).Unix()
+	if err := s.InsertRows([]Row{{Metric: "mem_load", DataPoint: DataPoint{Timestamp: borderline, Value: 9}}}); err != nil {
+		t.Fatalf("InsertRows error: %v", err)
+	}
+
+	// Age it out by rewriting its timestamp, then insert again to trigger the purge.
+	s.mu.Lock()
+	s.data["mem_load"][0].Timestamp = time.Now().Add(-retention - time.Hour).Unix()
+	s.mu.Unlock()
+
+	now := time.Now().Unix()
+	if err := s.InsertRows([]Row{{Metric: "cpu_load", DataPoint: DataPoint{Timestamp: now, Value: 1}}}); err != nil {
+		t.Fatalf("InsertRows error: %v", err)
+	}
+
+	points, err := s.Select("mem_load", nil, 0, now+60)
+	if err != nil {
+		t.Fatalf("Select error: %v", err)
+	}
+	if len(points) != 0 {
+		t.Errorf("expected expired metric to be purged, got %d points", len(points))
+	}
+}
+
+// CloseStorage used to be permanently terminal because of sync.Once, so a
+// subsequent GetStorageInstance() handed back a closed handle.
+func TestStorageInstanceIsReinitialisableAfterClose(t *testing.T) {
+	SetStorageType("memory")
+
+	first, err := GetStorageInstance()
+	if err != nil {
+		t.Fatalf("GetStorageInstance error: %v", err)
+	}
+	if first == nil {
+		t.Fatal("expected a storage instance")
+	}
+	if err := CloseStorage(); err != nil {
+		t.Fatalf("CloseStorage error: %v", err)
+	}
+
+	second, err := GetStorageInstance()
+	if err != nil {
+		t.Fatalf("GetStorageInstance after close error: %v", err)
+	}
+	if second == nil {
+		t.Fatal("expected a fresh storage instance after close")
+	}
+	if second == first {
+		t.Error("expected a new instance after CloseStorage, got the closed one back")
+	}
+
+	// A usable instance accepts writes.
+	if err := second.InsertRows([]Row{{Metric: "cpu_load", DataPoint: DataPoint{Timestamp: time.Now().Unix(), Value: 1}}}); err != nil {
+		t.Errorf("re-initialised storage rejected a write: %v", err)
+	}
+	if err := CloseStorage(); err != nil {
+		t.Fatalf("CloseStorage (cleanup) error: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #45. First of three PRs tracked by #47.

Three classes of problem, all reachable in normal operation, plus regression tests for each.

## Correctness

**Service health score was inverted on breach.** `calculateServiceHealth` clamped the score to `100` — the best possible value — when usage exceeded every threshold, so a fully degraded service reported as perfectly healthy. `calculateSystemHealth` already returned `0` in the same branch. They now agree.

**In-memory storage ignored the retention period.** `InMemoryStorage.InsertRows` appended unconditionally and never evicted, so `WithStorageType("memory")` grew without bound for the life of the process. It now drops points older than `common.GetDataRetentionPeriod()` and purges expired ones on insert.

**`WithStorageType` never took effect.** `setup()` called `SetDataPointsSyncFrequency` — which initialises the storage singleton — *before* `SetStorageType`. By the time the type was applied the instance already existed, so `"memory"` silently fell through to disk. The two calls are now ordered correctly.

## Races and leaks

- `serviceHealthThresholds` was written by `ConfigureServiceThresholds` and read from the metrics goroutine unsynchronised. Now behind an `RWMutex`, with a new `core.GetThresholds()` accessor; all read sites converted.
- `CloseStorage()` was permanently terminal via `sync.Once` — a later `GetStorageInstance()` returned the closed handle. Replaced with mutex-guarded init that can re-create.
- Each `SetDataPointsSyncFrequency` call leaked the previous ticker goroutine. Sync goroutines now carry their own cancellable context, cancelled on reconfigure and on close.
- `RateLimitMiddleware`'s cleanup goroutine outlived `Shutdown()` unless the caller manually invoked the returned `stop`. `Shutdown` now runs a cleanup registry.
- `WriteHeapProfile` never closed its file; `StopCPUProfile` dereferenced a possibly-nil handle.
- `registry.GetAll()` documented "a snapshot copy" but shallow-copied, sharing the `Labels` map with the live registry.

## Security

**Timing-attack surface on both auth middlewares.** `BasicAuthMiddleware` and `APIKeyMiddleware` compared credentials with `!=`, which short-circuits on the first differing byte and leaks length and prefix information. Both now use `crypto/subtle.ConstantTimeCompare`. A request carrying no credentials also now receives a `WWW-Authenticate` challenge rather than a bare 401.

**Argument injection into `go tool pprof`.** `ViewFunctionMetrics` passed a caller-supplied function name and report type straight into `exec.Command("go", "tool", "pprof", "-"+reportType, profilePath)`. A name beginning with `-` is read as a flag by pprof — `-output=…` writes an attacker-chosen file, `-http=…` opens a listener. Names starting with `-` or containing shell control characters are rejected, and the report type is restricted to `text`/`traces`/`tree`.

## Found while writing the tests

`common.ConvertToMB` slices `value[len(value)-2:]` without a length check, so any memory string shorter than three characters panics. It is reachable from health calculation via `calculateMemoryUsagePercentage`, which also divided by a possibly-zero total. Both are now guarded. This is why the diff touches `common/`.

## Also

- `TraceFunctionWithArgs` / `TraceFunctionWithReturns` panicked on a `nil` argument, because `reflect.ValueOf(nil).Type()` panics. Nillable parameter kinds now accept `nil` as the zero value; non-nillable kinds are rejected with a log.
- Argument marshalling is shared between the two trace helpers instead of duplicated.
- `Build()` rejects out-of-range thresholds rather than producing nonsense scores from them.
- `monigo.gif` re-encoded 65 MB → 24 MB. The blob stays in git history, so this does not shrink clones — but the module zip is what every `go get github.com/iyashjayesh/monigo` downloads. Same length and framerate content, 800px wide.

## Verification

```
go vet ./...                      clean
go test ./... -race -count=1      all packages pass
```

New tests: threshold bounds and concurrent access, health-score-zero-on-breach, service/system agreement, malformed memory input, in-memory retention and purge, storage re-init after close, pprof argument rejection and acceptance, nil trace arguments, auth partial-match rejection, and `Shutdown` stopping rate-limiter goroutines.

One test needed care: `TestCalculateServiceHealthWithinLimits` originally used `TotalCores = 1`, which makes the score depend on how busy the machine running CI happens to be. It now uses denominators large enough that the live CPU reading cannot dominate.

## Not addressed

Pre-existing `gofmt` drift in `monigo.go` (map literal alignment at lines ~473 and ~547), `common/common.go`, `core/core_test.go`, and `exporters/otel.go` is left alone to keep this diff reviewable. CI runs `go vet`, not `gofmt`.
