### PR TITLE
feat: add opt-in health breach webhook alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `registry.GetAll()` documented a snapshot copy but shared the `Labels` map with the live registry
 
 ### Added
+- Health breach webhook alerts via `WithAlertWebhook(url)` -- an opt-in `POST` fired when the system or service health score drops below 70. Dispatch is off the collection path, requests time out after 10 seconds, and deliveries are rate limited to one per 5 minutes across both alert types. `Build()` rejects a URL that is not `http://` or `https://`
+- `common.GetServiceName()` -- accessor for the configured service name
 - `core.GetThresholds()` -- thread-safe accessor for the configured health thresholds
 - `Build()` validates `MaxCPUUsage` and `MaxMemoryUsage` are within 0-100 and `MaxGoRoutines` is non-negative
 - Regression tests for every fix above

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ m := monigo.NewBuilder().
     WithMaxCPUUsage(90).                    // Health threshold (default: 95%)
     WithMaxMemoryUsage(90).                 // Health threshold (default: 95%)
     WithMaxGoRoutines(500).                 // Health threshold (default: 100)
+    WithAlertWebhook("https://...").        // Health breach webhook (default: off)
     WithHeadless(false).                    // true = no dashboard (default: false)
     WithTimeZone("UTC").                    // Timezone (default: "Local")
     WithLogLevel(slog.LevelInfo).           // Log level
@@ -105,6 +106,37 @@ m := monigo.NewBuilder().
     }).
     Build()
 ```
+
+### Health Breach Alerts
+
+MoniGo computes a system and service health score on every collection cycle. Point
+`WithAlertWebhook` at an HTTP endpoint to be notified when either score drops below
+70. Left unset, MoniGo makes no outbound requests.
+
+```go
+m := monigo.NewBuilder().
+    WithServiceName("order-service").
+    WithAlertWebhook("https://hooks.slack.com/services/...").
+    Build()
+```
+
+Delivery is `POST` with `Content-Type: application/json`:
+
+```json
+{
+  "service_name": "order-service",
+  "timestamp": "2026-08-28T11:59:20Z",
+  "message": "Service Health Alert: Service usage exceeds allowed limits: CPU Usage 143.20% / 95.00%, ...",
+  "health_score": 42.5
+}
+```
+
+Alerts are dispatched off the metrics collection path, so a slow or unreachable
+endpoint never stalls metric collection. Requests time out after 10 seconds, and a
+minimum of 5 minutes separates deliveries so a flapping service cannot emit an alert
+on every tick. Delivery failures are logged and otherwise ignored.
+
+`Build()` rejects a webhook URL that is not `http://` or `https://`.
 
 ## Function Tracing
 

--- a/common/common.go
+++ b/common/common.go
@@ -259,6 +259,11 @@ func GetServiceStartTime() time.Time {
 	return serviceInfo.ServiceStartTime
 }
 
+// GetServiceName returns the configured service name.
+func GetServiceName() string {
+	return serviceInfo.ServiceName
+}
+
 // parseDuration parses the duration string.
 func parseDuration(input string) (time.Duration, error) {
 	if strings.HasSuffix(input, "d") {

--- a/config_builder.go
+++ b/config_builder.go
@@ -3,6 +3,7 @@ package monigo
 import (
 	"log/slog"
 	"net/http"
+	"strings"
 
 	"github.com/iyashjayesh/monigo/internal/logger"
 )
@@ -103,6 +104,12 @@ func (b *MonigoBuilder) WithStorageType(storageType string) *MonigoBuilder {
 	return b
 }
 
+// WithAlertWebhook sets the health breach alert webhook URL
+func (b *MonigoBuilder) WithAlertWebhook(url string) *MonigoBuilder {
+	b.config.AlertWebhookURL = url
+	return b
+}
+
 // WithHeadless sets whether the dashboard should be started
 func (b *MonigoBuilder) WithHeadless(headless bool) *MonigoBuilder {
 	b.config.Headless = headless
@@ -147,6 +154,11 @@ func (b *MonigoBuilder) Build() *Monigo {
 	}
 	if b.config.StorageType != "" && b.config.StorageType != "disk" && b.config.StorageType != "memory" {
 		panic("[MoniGo] Build() failed: StorageType must be 'disk' or 'memory'")
+	}
+	if b.config.AlertWebhookURL != "" {
+		if !strings.HasPrefix(b.config.AlertWebhookURL, "http://") && !strings.HasPrefix(b.config.AlertWebhookURL, "https://") {
+			panic("[MoniGo] Build() failed: AlertWebhookURL must start with http:// or https://")
+		}
 	}
 	if b.config.MaxCPUUsage < 0 || b.config.MaxCPUUsage > 100 {
 		panic("[MoniGo] Build() failed: MaxCPUUsage must be between 0 and 100")

--- a/config_builder_test.go
+++ b/config_builder_test.go
@@ -126,3 +126,37 @@ func TestBuilderThresholdBounds(t *testing.T) {
 		})
 	}
 }
+
+func TestBuilderAlertWebhookValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		url       string
+		wantPanic bool
+	}{
+		{"https", "https://hooks.example.com/services/abc", false},
+		{"http", "http://localhost:9000/alerts", false},
+		{"unset", "", false},
+		{"no scheme", "hooks.example.com/services/abc", true},
+		{"wrong scheme", "ftp://hooks.example.com/abc", true},
+		{"shell-ish", "; rm -rf /", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				r := recover()
+				if tt.wantPanic && r == nil {
+					t.Errorf("expected Build() to panic for %q", tt.url)
+				}
+				if !tt.wantPanic && r != nil {
+					t.Errorf("expected Build() to accept %q, panicked with: %v", tt.url, r)
+				}
+			}()
+
+			m := NewBuilder().WithServiceName("test").WithAlertWebhook(tt.url).Build()
+			if m.AlertWebhookURL != tt.url {
+				t.Errorf("AlertWebhookURL = %q, want %q", m.AlertWebhookURL, tt.url)
+			}
+		})
+	}
+}

--- a/core/health-check.go
+++ b/core/health-check.go
@@ -5,6 +5,7 @@ import (
 	"runtime"
 
 	"github.com/iyashjayesh/monigo/common"
+	"github.com/iyashjayesh/monigo/internal/alerting"
 	"github.com/iyashjayesh/monigo/models"
 )
 
@@ -137,6 +138,14 @@ func CalculateHealthScore(serviceStats *models.ServiceStats) (*models.SystemHeal
 	serviceScore, serviceMsg, err := calculateServiceHealth(serviceStats)
 	if err != nil {
 		return nil, fmt.Errorf("failed to calculate service health: %w", err)
+	}
+
+	// Trigger alert webhooks on health score breach (< 70%)
+	if systemScore < 70 {
+		alerting.TriggerAlert(common.GetServiceName(), systemScore, "System Health Alert: "+systemMsg)
+	}
+	if serviceScore < 70 {
+		alerting.TriggerAlert(common.GetServiceName(), serviceScore, "Service Health Alert: "+serviceMsg)
 	}
 
 	t := GetThresholds()

--- a/internal/alerting/alerting.go
+++ b/internal/alerting/alerting.go
@@ -1,0 +1,115 @@
+package alerting
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/iyashjayesh/monigo/internal/logger"
+)
+
+// httpDoer is the subset of *http.Client that alert delivery needs. It exists so
+// tests can substitute a transport without mutating http.DefaultClient.
+type httpDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+const (
+	// deliveryTimeout bounds a single webhook request so a hanging endpoint
+	// cannot pin a goroutine indefinitely.
+	deliveryTimeout = 10 * time.Second
+	// defaultRateLimit is the minimum interval between deliveries. A flapping
+	// service would otherwise emit an alert on every collection tick.
+	defaultRateLimit = 5 * time.Minute
+)
+
+var (
+	mu             sync.RWMutex
+	webhookURL     string
+	lastAlert      time.Time
+	alertRateLimit          = defaultRateLimit
+	client         httpDoer = &http.Client{Timeout: deliveryTimeout}
+)
+
+// SetWebhookURL sets the webhook URL.
+func SetWebhookURL(url string) {
+	mu.Lock()
+	defer mu.Unlock()
+	webhookURL = url
+}
+
+// GetWebhookURL returns the webhook URL.
+func GetWebhookURL() string {
+	mu.RLock()
+	defer mu.RUnlock()
+	return webhookURL
+}
+
+// currentClient returns the client used to deliver alerts.
+func currentClient() httpDoer {
+	mu.RLock()
+	defer mu.RUnlock()
+	return client
+}
+
+// AlertPayload defines the schema for the webhook payload.
+type AlertPayload struct {
+	ServiceName string    `json:"service_name"`
+	Timestamp   time.Time `json:"timestamp"`
+	Message     string    `json:"message"`
+	HealthScore float64   `json:"health_score"`
+}
+
+// TriggerAlert asynchronously dispatches a health breach webhook if configured.
+func TriggerAlert(serviceName string, score float64, message string) {
+	mu.Lock()
+	url := webhookURL
+	if url == "" {
+		mu.Unlock()
+		return
+	}
+	if time.Since(lastAlert) < alertRateLimit {
+		mu.Unlock()
+		return
+	}
+	lastAlert = time.Now()
+	mu.Unlock()
+
+	go func() {
+		payload := AlertPayload{
+			ServiceName: serviceName,
+			Timestamp:   time.Now(),
+			Message:     message,
+			HealthScore: score,
+		}
+		data, err := json.Marshal(payload)
+		if err != nil {
+			logger.Log.Error("failed to marshal alert payload", "error", err)
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), deliveryTimeout)
+		defer cancel()
+
+		req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(data))
+		if err != nil {
+			logger.Log.Error("failed to create alert request", "error", err)
+			return
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := currentClient().Do(req)
+		if err != nil {
+			logger.Log.Error("failed to send alert webhook", "error", err)
+			return
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			logger.Log.Error("alert webhook returned non-success status", "status", resp.Status)
+		}
+	}()
+}

--- a/internal/alerting/alerting_test.go
+++ b/internal/alerting/alerting_test.go
@@ -1,0 +1,201 @@
+package alerting
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+)
+
+// recorder is a stub httpDoer that captures every delivery attempt.
+type recorder struct {
+	mu       sync.Mutex
+	requests []AlertPayload
+	status   int
+	err      error
+}
+
+func (r *recorder) Do(req *http.Request) (*http.Response, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.err != nil {
+		return nil, r.err
+	}
+
+	var p AlertPayload
+	if err := json.NewDecoder(req.Body).Decode(&p); err == nil {
+		r.requests = append(r.requests, p)
+	}
+
+	status := r.status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(bytes.NewReader(nil)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func (r *recorder) calls() []AlertPayload {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]AlertPayload(nil), r.requests...)
+}
+
+// install swaps in a recorder and a rate limit for the duration of a test, and
+// restores every piece of package state afterwards so tests do not leak into
+// one another.
+func install(t *testing.T, rl time.Duration) *recorder {
+	t.Helper()
+	rec := &recorder{}
+
+	mu.Lock()
+	prevClient, prevLimit, prevURL, prevLast := client, alertRateLimit, webhookURL, lastAlert
+	client, alertRateLimit, lastAlert = rec, rl, time.Time{}
+	mu.Unlock()
+
+	t.Cleanup(func() {
+		mu.Lock()
+		client, alertRateLimit, webhookURL, lastAlert = prevClient, prevLimit, prevURL, prevLast
+		mu.Unlock()
+	})
+	return rec
+}
+
+// settle waits for the asynchronous delivery goroutine to reach the recorder.
+func settle(t *testing.T, rec *recorder, want int) []AlertPayload {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if got := rec.calls(); len(got) >= want {
+			return got
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return rec.calls()
+}
+
+func TestTriggerAlertDeliversPayload(t *testing.T) {
+	rec := install(t, time.Minute)
+	SetWebhookURL("https://example.com/webhook")
+
+	TriggerAlert("test-service", 65.5, "Memory usage too high")
+
+	got := settle(t, rec, 1)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 delivery, got %d", len(got))
+	}
+	if got[0].ServiceName != "test-service" {
+		t.Errorf("ServiceName = %q, want %q", got[0].ServiceName, "test-service")
+	}
+	if got[0].HealthScore != 65.5 {
+		t.Errorf("HealthScore = %v, want 65.5", got[0].HealthScore)
+	}
+	if got[0].Message != "Memory usage too high" {
+		t.Errorf("Message = %q, want %q", got[0].Message, "Memory usage too high")
+	}
+	if got[0].Timestamp.IsZero() {
+		t.Error("expected a non-zero Timestamp")
+	}
+}
+
+// An unconfigured webhook must produce no outbound traffic at all.
+func TestTriggerAlertIsOptIn(t *testing.T) {
+	rec := install(t, time.Minute)
+	SetWebhookURL("")
+
+	TriggerAlert("test-service", 10, "should not be delivered")
+
+	time.Sleep(100 * time.Millisecond)
+	if got := rec.calls(); len(got) != 0 {
+		t.Errorf("expected no deliveries with no webhook configured, got %d", len(got))
+	}
+}
+
+// A flapping service must not emit an alert on every collection tick, and the
+// limiter is shared across system and service alerts.
+func TestTriggerAlertIsRateLimited(t *testing.T) {
+	rec := install(t, time.Hour)
+	SetWebhookURL("https://example.com/webhook")
+
+	TriggerAlert("test-service", 65.5, "first")
+	settle(t, rec, 1)
+
+	TriggerAlert("test-service", 60.0, "second")
+	TriggerAlert("test-service", 55.0, "third")
+	time.Sleep(100 * time.Millisecond)
+
+	if got := rec.calls(); len(got) != 1 {
+		t.Errorf("expected subsequent alerts to be rate limited, got %d deliveries", len(got))
+	}
+}
+
+// Once the interval has elapsed, alerting resumes.
+func TestTriggerAlertResumesAfterRateLimitWindow(t *testing.T) {
+	rec := install(t, 50*time.Millisecond)
+	SetWebhookURL("https://example.com/webhook")
+
+	TriggerAlert("test-service", 65.5, "first")
+	settle(t, rec, 1)
+
+	time.Sleep(80 * time.Millisecond)
+	TriggerAlert("test-service", 60.0, "second")
+
+	if got := settle(t, rec, 2); len(got) != 2 {
+		t.Errorf("expected delivery to resume after the window, got %d", len(got))
+	}
+}
+
+// Delivery failures are logged, never fatal, and must not stall the caller.
+func TestTriggerAlertToleratesDeliveryFailure(t *testing.T) {
+	t.Run("non-2xx response", func(t *testing.T) {
+		rec := install(t, time.Minute)
+		rec.status = http.StatusInternalServerError
+		SetWebhookURL("https://example.com/webhook")
+
+		TriggerAlert("test-service", 20, "boom")
+		if got := settle(t, rec, 1); len(got) != 1 {
+			t.Errorf("expected the delivery to be attempted, got %d", len(got))
+		}
+	})
+
+	t.Run("transport error", func(t *testing.T) {
+		rec := install(t, time.Minute)
+		rec.err = http.ErrHandlerTimeout
+		SetWebhookURL("https://example.com/webhook")
+
+		TriggerAlert("test-service", 20, "boom")
+		time.Sleep(100 * time.Millisecond) // must not panic or block
+	})
+}
+
+func TestWebhookURLRoundTrips(t *testing.T) {
+	install(t, time.Minute)
+
+	SetWebhookURL("https://example.com/hook")
+	if got := GetWebhookURL(); got != "https://example.com/hook" {
+		t.Errorf("GetWebhookURL() = %q, want %q", got, "https://example.com/hook")
+	}
+}
+
+// TriggerAlert is called from the metrics collection path; concurrent calls must
+// be safe. Run under -race.
+func TestTriggerAlertConcurrent(t *testing.T) {
+	install(t, time.Millisecond)
+	SetWebhookURL("https://example.com/webhook")
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(2)
+		go func() { defer wg.Done(); TriggerAlert("svc", 10, "concurrent") }()
+		go func() { defer wg.Done(); _ = GetWebhookURL() }()
+	}
+	wg.Wait()
+	time.Sleep(50 * time.Millisecond)
+}

--- a/monigo.go
+++ b/monigo.go
@@ -22,6 +22,7 @@ import (
 	"github.com/iyashjayesh/monigo/common"
 	"github.com/iyashjayesh/monigo/core"
 	"github.com/iyashjayesh/monigo/exporters"
+	"github.com/iyashjayesh/monigo/internal/alerting"
 	"github.com/iyashjayesh/monigo/internal/logger"
 	"github.com/iyashjayesh/monigo/models"
 	"github.com/iyashjayesh/monigo/timeseries"
@@ -69,6 +70,7 @@ type Monigo struct {
 	Headless                bool      `json:"headless"`
 	SamplingRate            int       `json:"sampling_rate"`
 	StorageType             string    `json:"storage_type"`
+	AlertWebhookURL         string    `json:"alert_webhook_url,omitempty"`
 
 	// OpenTelemetry Configuration
 	OTelEndpoint string            `json:"otel_endpoint,omitempty"`
@@ -158,6 +160,10 @@ func (m *Monigo) initCommon() {
 		MaxMemoryUsage: m.MaxMemoryUsage,
 		MaxGoRoutines:  m.MaxGoRoutines,
 	})
+
+	if m.AlertWebhookURL != "" {
+		alerting.SetWebhookURL(m.AlertWebhookURL)
+	}
 
 	m.ServiceStartTime = time.Now().In(location)
 }


### PR DESCRIPTION
Closes #46. Second of three PRs tracked by #47.

> **Stacked on #48.** Base branch is `fix/stability-and-security`, so the diff shown here is alerting-only. Merge #48 first; this PR retargets to `main` automatically once it lands.

MoniGo computes a system and service health score on every collection cycle, but that score has only ever been observable by someone looking at the dashboard. There is no way to be told when a service degrades.

## API

```go
m := monigo.NewBuilder().
    WithServiceName("order-service").
    WithAlertWebhook("https://hooks.slack.com/services/...").
    Build()
```

Unset — the default — means MoniGo makes no outbound requests at all.

## Payload

`POST`, `Content-Type: application/json`, fired when either health score drops below 70:

```json
{
  "service_name": "order-service",
  "timestamp": "2026-08-28T11:59:20Z",
  "message": "Service Health Alert: Service usage exceeds allowed limits: CPU Usage 143.20% / 95.00%, ...",
  "health_score": 42.5
}
```

## Design constraints

**Opt-in.** `TriggerAlert` returns before touching the network when no URL is configured.

**Non-blocking.** Delivery runs on its own goroutine, off the metrics collection path, with a 10s request timeout. A slow or unreachable endpoint cannot stall collection or pin a goroutine indefinitely.

**Rate limited.** A flapping service would otherwise emit an alert on every collection tick, so a minimum of 5 minutes separates deliveries. The limiter is shared across system and service alerts rather than per-type, because a service in trouble usually breaches both at once — two alerts describing one incident is noise.

**Validated early.** `Build()` rejects a URL that is not `http://` or `https://`, rather than deferring the failure to the first delivery attempt, which might be hours after startup.

**Non-fatal.** A non-2xx response or transport error is logged through the structured logger and otherwise ignored. Alerting must never take down the service it is monitoring.

## Why this is stacked rather than parallel

The alert fires on a health score that #48 fixes. On `main` today, `calculateServiceHealth` returns `100` on breach instead of `0` — so an alert built against current behaviour would trigger on precisely the inverted condition: never when the service is degraded, always when it is healthy. This PR is only correct on top of #48.

## Testability

`internal/alerting` holds its HTTP client behind a package-level `httpDoer` interface so tests substitute a transport instead of mutating `http.DefaultClient`. Every test restores the package state it touched via `t.Cleanup`, so ordering does not matter.

## Verification

```
go vet ./...                      clean
go test ./... -race -count=1      all packages pass
```

Covered: payload contents and shape, opt-in silence when unconfigured, rate limiting, resumption after the window elapses, tolerance of both non-2xx responses and transport errors, URL round-trip, concurrent `TriggerAlert` under `-race`, and `Build()` accepting/rejecting URL forms.

## Scope

The threshold is fixed at 70 for this first cut. Configurable thresholds, per-severity routing, and recovery ("service recovered") notifications are deliberate follow-ups — worth filing once this shape has seen real use.
