### PR TITLE
feat(dashboard): add dark mode, loading states, and grouped goroutine stacks

### DIFF
--- a/static/css/monigo-styles.css
+++ b/static/css/monigo-styles.css
@@ -96,4 +96,443 @@
     margin-left: 30px;
 }
 
-/* Function Stack View CSS */
+/* --- Premium Styling System & Dark Mode --- */
+
+/* Global Premium Styling Overrides */
+.card {
+    border-radius: 12px !important;
+    border: 1px solid #e5e7eb !important;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -1px rgba(0, 0, 0, 0.03) !important;
+    transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1), box-shadow 0.25s cubic-bezier(0.4, 0, 0.2, 1), border-color 0.25s ease !important;
+}
+
+.card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.08), 0 4px 6px -2px rgba(0, 0, 0, 0.04) !important;
+    border-color: rgba(255, 92, 53, 0.3) !important;
+}
+
+/* Theme Toggle Button Styling */
+#theme-toggle-btn {
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1) !important;
+    border-radius: 50% !important;
+    width: 38px !important;
+    height: 38px !important;
+    padding: 0 !important;
+    display: inline-flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    background-color: #f3f4f6 !important;
+    border: 1px solid #e5e7eb !important;
+    color: #4b5563 !important;
+}
+
+#theme-toggle-btn:hover {
+    transform: scale(1.1) rotate(15deg);
+    background-color: #e5e7eb !important;
+    color: #ff5c35 !important;
+    box-shadow: 0 0 12px rgba(255, 92, 53, 0.25) !important;
+}
+
+/* Modern Progress Bars */
+.iq-progress-bar {
+    height: 7px !important;
+    border-radius: 6px !important;
+    background-color: #f3f4f6 !important;
+    overflow: hidden !important;
+    margin-top: 12px !important;
+    padding: 0 !important;
+}
+
+.iq-progress {
+    height: 100% !important;
+    border-radius: 6px !important;
+    display: block !important;
+    background-color: #ff5c35 !important;
+}
+
+/* Icon Box Polish */
+.iq-icon-box-2 {
+    border-radius: 10px !important;
+    display: inline-flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    width: 44px !important;
+    height: 44px !important;
+    padding: 8px !important;
+    margin-right: 12px !important;
+    transition: background-color 0.2s ease !important;
+}
+
+/* Dark Mode Colors & Styling */
+body.dark-theme {
+    background-color: #0b0f19 !important;
+    color: #f3f4f6 !important;
+}
+
+body.dark-theme .wrapper {
+    background-color: #0b0f19 !important;
+}
+
+body.dark-theme .iq-sidebar {
+    background-color: #111827 !important;
+    border-right: 1px solid #1f2937 !important;
+}
+
+body.dark-theme .iq-sidebar-logo {
+    border-bottom: 1px solid #1f2937 !important;
+    background-color: #111827 !important;
+}
+
+body.dark-theme .iq-sidebar-menu ul li a {
+    color: #9ca3af !important;
+}
+
+body.dark-theme .iq-sidebar-menu ul li a i,
+body.dark-theme .iq-sidebar-menu ul li a svg {
+    color: #9ca3af !important;
+    fill: #9ca3af !important;
+    transition: color 0.2s, fill 0.2s !important;
+}
+
+body.dark-theme .iq-sidebar-menu ul li.active > a,
+body.dark-theme .iq-sidebar-menu ul li a:hover {
+    color: #ff5c35 !important;
+    background-color: #1f2937 !important;
+}
+
+body.dark-theme .iq-sidebar-menu ul li.active > a i,
+body.dark-theme .iq-sidebar-menu ul li.active > a svg,
+body.dark-theme .iq-sidebar-menu ul li a:hover i,
+body.dark-theme .iq-sidebar-menu ul li a:hover svg {
+    color: #ff5c35 !important;
+    fill: #ff5c35 !important;
+}
+
+body.dark-theme .card {
+    background-color: #111827 !important;
+    border: 1px solid #1f2937 !important;
+    color: #f3f4f6 !important;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.4), 0 2px 4px -1px rgba(0, 0, 0, 0.2) !important;
+}
+
+body.dark-theme .card:hover {
+    box-shadow: 0 12px 20px -3px rgba(0, 0, 0, 0.6), 0 8px 10px -2px rgba(0, 0, 0, 0.4) !important;
+    border-color: rgba(255, 92, 53, 0.45) !important;
+}
+
+body.dark-theme .card-header,
+body.dark-theme .card-footer {
+    background-color: #1f2937 !important;
+    border-bottom: 1px solid #374151 !important;
+    color: #f3f4f6 !important;
+}
+
+body.dark-theme .iq-top-navbar {
+    background-color: #111827 !important;
+    border-bottom: 1px solid #1f2937 !important;
+}
+
+body.dark-theme .navbar {
+    background-color: #111827 !important;
+}
+
+body.dark-theme .navbar-list {
+    background-color: #1f2937 !important;
+    color: #f3f4f6 !important;
+}
+
+body.dark-theme .text-muted,
+body.dark-theme .dropdown-label {
+    color: #9ca3af !important;
+}
+
+body.dark-theme .table {
+    color: #f3f4f6 !important;
+}
+
+body.dark-theme .table th {
+    border-color: #1f2937 !important;
+    background-color: #1f2937 !important;
+}
+
+body.dark-theme .table td {
+    border-color: #1f2937 !important;
+}
+
+body.dark-theme .table tbody tr:hover {
+    background-color: #1f2937 !important;
+}
+
+body.dark-theme .modal-content {
+    background-color: #111827 !important;
+    color: #f3f4f6 !important;
+    border: 1px solid #1f2937 !important;
+}
+
+body.dark-theme .modal-header {
+    border-bottom: 1px solid #1f2937 !important;
+}
+
+body.dark-theme .modal-footer {
+    border-top: 1px solid #1f2937 !important;
+}
+
+body.dark-theme .dropdown-select {
+    background-color: #1f2937 !important;
+    color: #f3f4f6 !important;
+    border: 1px solid #374151 !important;
+}
+
+body.dark-theme #theme-toggle-btn {
+    background-color: #1f2937 !important;
+    border-color: #374151 !important;
+    color: #f3f4f6 !important;
+}
+
+body.dark-theme #theme-toggle-btn:hover {
+    background-color: #374151 !important;
+    color: #ff5c35 !important;
+}
+
+body.dark-theme .iq-progress-bar {
+    background-color: #1f2937 !important;
+}
+
+body.dark-theme .iq-icon-box-2 {
+    background-color: #1f2937 !important;
+    border: 1px solid #374151 !important;
+}
+
+body.dark-theme .goroutine-card {
+    background-color: #1f2937 !important;
+    border-color: #374151 !important;
+}
+
+body.dark-theme pre {
+    background-color: #0b0f19 !important;
+    color: #34d399 !important;
+    border: 1px solid #1f2937 !important;
+    border-radius: 8px !important;
+    padding: 16px !important;
+    font-family: 'Fira Code', 'Courier New', Courier, monospace !important;
+}
+
+body.dark-theme .gauge,
+.gauge {
+    background: none !important;
+    display: block !important;
+    margin: 15px auto !important;
+    width: auto !important;
+    height: auto !important;
+    aspect-ratio: auto !important;
+}
+
+body.dark-theme .gauge::after,
+.gauge::after {
+    display: none !important;
+}
+
+/* Typography polish */
+body {
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif !important;
+}
+
+/* Brand Buttons */
+.btn-primary, #download-image-btn, #download-stack-view, #downloadBtn, .sidebar-bottom-btn {
+    background-color: #ff5c35 !important;
+    border-color: #ff5c35 !important;
+    color: #ffffff !important;
+    border-radius: 8px !important;
+    font-weight: 600 !important;
+    transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1) !important;
+    box-shadow: 0 4px 6px -1px rgba(255, 92, 53, 0.15), 0 2px 4px -1px rgba(255, 92, 53, 0.1) !important;
+}
+
+.btn-primary:hover, #download-image-btn:hover, #download-stack-view:hover, #downloadBtn:hover, .sidebar-bottom-btn:hover {
+    background-color: #e04b24 !important;
+    border-color: #e04b24 !important;
+    color: #ffffff !important;
+    transform: translateY(-1px) !important;
+    box-shadow: 0 6px 12px -2px rgba(255, 92, 53, 0.3), 0 4px 6px -2px rgba(255, 92, 53, 0.2) !important;
+}
+
+.sidebar-bottom-btn a {
+    color: #ffffff !important;
+    text-decoration: none !important;
+}
+
+/* GitHub Icon Wrapper Circular Style */
+.navbar-list li.nav-item.nav-icon.dropdown a {
+    display: inline-flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    width: 38px !important;
+    height: 38px !important;
+    border-radius: 50% !important;
+    background-color: #f3f4f6 !important;
+    border: 1px solid #e5e7eb !important;
+    color: #4b5563 !important;
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+
+body.dark-theme .navbar-list li.nav-item.nav-icon.dropdown a {
+    background-color: #1f2937 !important;
+    border-color: #374151 !important;
+    color: #f3f4f6 !important;
+}
+
+.navbar-list li.nav-item.nav-icon.dropdown a:hover {
+    transform: scale(1.1);
+    background-color: #e5e7eb !important;
+    color: #ff5c35 !important;
+    box-shadow: 0 0 12px rgba(255, 92, 53, 0.25) !important;
+}
+
+body.dark-theme .navbar-list li.nav-item.nav-icon.dropdown a:hover {
+    background-color: #374151 !important;
+    color: #ff5c35 !important;
+}
+
+.navbar-list li.nav-item.nav-icon.dropdown a i.fa-github {
+    font-size: 18px !important;
+    margin: 0 !important;
+}
+
+/* Countdown Pill Style */
+.add-btn {
+    border-radius: 20px !important;
+    padding: 6px 16px !important;
+    font-size: 13px !important;
+    font-weight: 500 !important;
+    background-color: transparent !important;
+    border-color: #e5e7eb !important;
+    color: #4b5563 !important;
+    transition: all 0.2s ease !important;
+}
+
+body.dark-theme .add-btn {
+    border-color: #374151 !important;
+    color: #9ca3af !important;
+}
+
+/* Skeleton Text Animation */
+.skeleton-text {
+    font-size: 1.15rem !important;
+    font-weight: 500 !important;
+    color: #9ca3af !important;
+}
+
+body.dark-theme .skeleton-text {
+    color: #6b7280 !important;
+}
+
+@keyframes pulse {
+    0%, 100% { opacity: 0.8; }
+    50% { opacity: 0.35; }
+}
+
+.animate-pulse {
+    animation: pulse 1.8s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+
+/* Secondary Outlined Buttons for Detailed View */
+.card-body .btn-primary {
+    background-color: transparent !important;
+    border: 1px solid #ff5c35 !important;
+    color: #ff5c35 !important;
+    font-weight: 500 !important;
+    font-size: 13px !important;
+    padding: 6px 14px !important;
+    box-shadow: none !important;
+    transition: all 0.2s ease-in-out !important;
+}
+
+.card-body .btn-primary:hover {
+    background-color: #ff5c35 !important;
+    color: #ffffff !important;
+    transform: translateY(-1px);
+    box-shadow: 0 4px 10px rgba(255, 92, 53, 0.2) !important;
+}
+
+body.dark-theme .card-body .btn-primary {
+    border-color: #ff5c35 !important;
+    color: #ff5c35 !important;
+}
+
+body.dark-theme .card-body .btn-primary:hover {
+    background-color: #ff5c35 !important;
+    color: #ffffff !important;
+}
+
+/* Sidebar Bottom Card Custom Styling */
+.sidebar-bottom .card.bg-success-light {
+    background-color: rgba(255, 255, 255, 0.04) !important;
+    border: 1px solid rgba(255, 255, 255, 0.08) !important;
+    border-radius: 12px !important;
+    margin: 15px !important;
+}
+
+.sidebar-bottom .card.bg-success-light h6 {
+    color: #9ca3af !important;
+    font-size: 12px !important;
+    line-height: 1.6 !important;
+    font-weight: 400 !important;
+}
+
+.sidebar-bottom .card.bg-success-light .sidebar-bottom-btn {
+    background-color: #ff5c35 !important;
+    border: none !important;
+    width: 100% !important;
+    border-radius: 8px !important;
+    padding: 8px 12px !important;
+    transition: all 0.2s ease-in-out !important;
+}
+
+.sidebar-bottom .card.bg-success-light .sidebar-bottom-btn a {
+    color: #ffffff !important;
+    font-weight: 600 !important;
+    font-size: 13px !important;
+    text-decoration: none !important;
+}
+
+.sidebar-bottom .card.bg-success-light .sidebar-bottom-btn:hover {
+    transform: translateY(-1px) !important;
+    box-shadow: 0 4px 12px rgba(255, 92, 53, 0.3) !important;
+}
+
+/* Remove all static decorative progress bars from metric cards */
+.card-body .iq-progress-bar {
+    display: none !important;
+}
+
+/* Harmonize icon box colors with brand orange */
+.iq-icon-box-2 {
+    background-color: rgba(255, 92, 53, 0.06) !important;
+    border-radius: 10px !important;
+    width: 44px !important;
+    height: 44px !important;
+    display: inline-flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    transition: all 0.2s ease !important;
+}
+
+body.dark-theme .iq-icon-box-2 {
+    background-color: rgba(255, 92, 53, 0.12) !important;
+}
+
+.iq-icon-box-2 img {
+    max-width: 22px !important;
+    max-height: 22px !important;
+    filter: drop-shadow(0 2px 4px rgba(255, 92, 53, 0.15));
+}
+
+.card:hover .iq-icon-box-2 {
+    transform: scale(1.05);
+    background-color: rgba(255, 92, 53, 0.1) !important;
+}
+
+body.dark-theme .card:hover .iq-icon-box-2 {
+    background-color: rgba(255, 92, 53, 0.18) !important;
+}

--- a/static/index.html
+++ b/static/index.html
@@ -190,8 +190,9 @@
                                     <div id="system-health-tag"></div>
                                 </div>
                                 <div class="gauge" id="g1">
-                                    <svg viewBox="0 0 60 25">
-                                        <text x="50%" y="50%">...</text>
+                                    <svg class="radial-ring" viewBox="0 0 100 100" style="width: 120px; height: 120px; margin: 0 auto; display: block;">
+                                        <circle cx="50" cy="50" r="40" fill="transparent" stroke="rgba(156, 163, 175, 0.2)" stroke-width="8"></circle>
+                                        <text x="50" y="56" text-anchor="middle" font-size="16" font-weight="bold" fill="#9ca3af">--%</text>
                                     </svg>
                                 </div>
                             </div>

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -58,6 +58,64 @@ document.addEventListener('DOMContentLoaded', () => {
         return fetch(url, options);
     }
 
+    // 1. Theme Configuration & Toggle Initialization (Synchronous, prioritized)
+    const savedTheme = localStorage.getItem('monigo-theme') || 'light';
+    
+    // Inject theme toggle button into the correct, visible top right navbar-list
+    const navbarList = document.querySelector('#navbarSupportedContent .navbar-list') || document.querySelector('.navbar-nav.navbar-list');
+    if (navbarList) {
+        const toggleLi = document.createElement('li');
+        toggleLi.className = 'nav-item nav-icon ml-3';
+        
+        const toggleLink = document.createElement('a');
+        toggleLink.id = 'theme-toggle-btn';
+        toggleLink.className = 'cursor-pointer';
+        toggleLink.innerHTML = '<i class="fa fa-moon-o" aria-hidden="true" style="font-size: 16px;"></i>';
+        
+        toggleLi.appendChild(toggleLink);
+        navbarList.appendChild(toggleLi);
+        
+        // Add event listener to toggle theme
+        toggleLink.addEventListener('click', () => {
+            const currentTheme = document.body.classList.contains('dark-theme') ? 'dark' : 'light';
+            const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+            setTheme(newTheme);
+        });
+    }
+
+    function setTheme(theme) {
+        if (theme === 'dark') {
+            document.body.classList.add('dark-theme');
+            localStorage.setItem('monigo-theme', 'dark');
+            const icon = document.querySelector('#theme-toggle-btn i');
+            if (icon) {
+                icon.className = 'fa fa-sun-o';
+            }
+        } else {
+            document.body.classList.remove('dark-theme');
+            localStorage.setItem('monigo-theme', 'light');
+            const icon = document.querySelector('#theme-toggle-btn i');
+            if (icon) {
+                icon.className = 'fa fa-moon-o';
+            }
+        }
+        // Emit event to notify other scripts (like charts) to update colors
+        document.dispatchEvent(new CustomEvent('monigoThemeChanged', { detail: { theme } }));
+    }
+
+    // Apply saved theme preference immediately
+    setTheme(savedTheme);
+
+    // 2. Pre-populate all chart containers with a stylized loading spinner
+    document.querySelectorAll('.chart-container').forEach(el => {
+        el.innerHTML = `
+            <div class="d-flex flex-column align-items-center justify-content-center h-100 text-muted" style="min-height: 200px;">
+                <i class="fa fa-refresh fa-spin fa-2x mb-3" style="color: #ff5c35;"></i>
+                <span class="small font-weight-bold">Awaiting MoniGo server connection...</span>
+            </div>
+        `;
+    });
+
     const elements = {
         healthMessage: document.getElementById('health-message'),
     };
@@ -68,20 +126,20 @@ document.addEventListener('DOMContentLoaded', () => {
         authenticatedFetch(`/monigo/api/v1/metrics`)
             .then(response => response.json())
             .then(data => {
-                const {
-                    // core_statistics,
-                    // load_statistics,
-                    // cpu_statistics,
-                    // memory_statistics,
-                    health
-                } = data;
+                const { health } = data;
                 const healthIndicator = document.getElementById('health-indicator');
-                if (health.service_health.healthy) {
-                    healthIndicator.classList.add('healthy');
-                    document.getElementById('health-message').textContent = health.service_health.message;
-                } else {
-                    healthIndicator.classList.add('unhealthy');
-                    document.getElementById('health-message').textContent = health.service_health.message;
+                if (healthIndicator) {
+                    if (health.service_health.healthy) {
+                        healthIndicator.classList.remove('unhealthy');
+                        healthIndicator.classList.add('healthy');
+                    } else {
+                        healthIndicator.classList.remove('healthy');
+                        healthIndicator.classList.add('unhealthy');
+                    }
+                }
+                const healthMsgEl = document.getElementById('health-message');
+                if (healthMsgEl) {
+                    healthMsgEl.textContent = health.service_health.message;
                 }
             })
             .catch(error => {
@@ -89,6 +147,6 @@ document.addEventListener('DOMContentLoaded', () => {
             });
     }
 
-    // on page refresh
+    // Fetch metrics on load
     fetchMetrics();
 });

--- a/static/js/goroutines.js
+++ b/static/js/goroutines.js
@@ -75,11 +75,11 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     const goroutinesChart = document.getElementById('goroutines-chart');
+    let goroutinesChartChartObj = null;
 
     function fetchDataPointsFromServer() {
         let StartTime = new Date();
         let EndTime = new Date();
-
 
         StartTime = new Date(new Date().getTime() - 60 * 60000); // Subtract 1 hour
         EndTime = new Date(); // Current time
@@ -91,7 +91,6 @@ document.addEventListener('DOMContentLoaded', () => {
             start_time: toLocalISOString(StartTime),
             end_time: toLocalISOString(EndTime)
         };
-
 
         authenticatedFetch(`/monigo/api/v1/service-metrics`, {
             method: 'POST',
@@ -110,21 +109,32 @@ document.addEventListener('DOMContentLoaded', () => {
                     });
                 }
 
-                const goroutinesChartChartObj = echarts.init(goroutinesChart);
-                const time = rawData.map(entry => entry.time);
+                window.lastGoroutinesRawData = rawData;
+
+                const isDark = document.body.classList.contains('dark-theme');
+                const textColor = isDark ? '#9ca3af' : '#333';
+                const gridLineColor = isDark ? '#1f2937' : '#eee';
+
+                if (!goroutinesChartChartObj && goroutinesChart) {
+                    goroutinesChartChartObj = echarts.init(goroutinesChart);
+                }
+                const time = rawData.map(entry => entry.time.toLocaleTimeString());
                 const goroutines = rawData.map(entry => entry.value.goroutines);
 
                 const option = {
+                    backgroundColor: 'transparent',
                     title: {
                         text: 'Goroutines Metrics for last 1 hour',
-                        left: 'center'
+                        left: 'center',
+                        textStyle: { color: isDark ? '#f3f4f6' : '#333' }
                     },
                     tooltip: {
                         trigger: 'axis'
                     },
                     legend: {
                         data: ['Goroutines'],
-                        top: 30
+                        top: 30,
+                        textStyle: { color: textColor }
                     },
                     grid: {
                         left: '3%',
@@ -135,15 +145,20 @@ document.addEventListener('DOMContentLoaded', () => {
                     xAxis: {
                         type: 'category',
                         boundaryGap: false,
-                        data: time
+                        data: time,
+                        axisLabel: { color: textColor },
+                        axisLine: { lineStyle: { color: gridLineColor } }
                     },
                     yAxis: {
-                        type: 'value'
+                        type: 'value',
+                        axisLabel: { color: textColor },
+                        splitLine: { lineStyle: { color: gridLineColor } }
                     },
                     series: [{
                         name: 'Goroutines',
                         type: 'line',
-                        data: goroutines
+                        data: goroutines,
+                        itemStyle: { color: '#ff5c35' }
                     }]
                 };
 
@@ -173,7 +188,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
                 fetchDataPointsFromServer();
 
-
                 if (goroutines.length > 0) {
                     const downloadBtn = document.getElementById('download-stack-view');
                     if (downloadBtn) {
@@ -189,27 +203,124 @@ document.addEventListener('DOMContentLoaded', () => {
                             a.click();
                             URL.revokeObjectURL(url);
                         });
-                    } else {
-                        downloadBtn.style.display = 'none';
                     }
                 }
 
                 countElement.textContent = goroutines.length;
                 container.innerHTML = '';
 
-                // Iterate over each goroutine and create HTML content
-                goroutines.forEach(goroutine => {
-                    const div = document.createElement('div');
-                    div.className = 'goroutine';
-                    div.innerHTML = `
-                        <div class="goroutine-header">Goroutine ${goroutine.id}:</div>
-                        <pre>${goroutine.stackTrace}</pre>
-                    `;
-                    container.appendChild(div);
+                // Group identical stack traces (ignoring the specific goroutine ID / state line)
+                const groups = {};
+                goroutines.forEach(g => {
+                    const lines = g.stackTrace.trim().split('\n');
+                    const header = lines[0] || '';
+                    const callStack = lines.slice(1).join('\n');
+
+                    let state = "unknown";
+                    const stateMatch = header.match(/\[(.*)\]/);
+                    if (stateMatch) {
+                        state = stateMatch[1];
+                    }
+
+                    if (!groups[callStack]) {
+                        groups[callStack] = {
+                            callStack: callStack,
+                            state: state,
+                            headers: [],
+                            count: 0
+                        };
+                    }
+                    groups[callStack].headers.push(header);
+                    groups[callStack].count++;
                 });
+
+                // Sort groups by count descending
+                const sortedGroups = Object.values(groups).sort((a, b) => b.count - a.count);
+
+                // Render with virtualization / safety limit of 50 groups
+                const displayLimit = 50;
+                const displayedGroups = sortedGroups.slice(0, displayLimit);
+
+                displayedGroups.forEach((group, index) => {
+                    const groupDiv = document.createElement('div');
+                    groupDiv.className = 'goroutine-card card mb-3';
+
+                    const headerDiv = document.createElement('div');
+                    headerDiv.className = 'card-header d-flex justify-content-between align-items-center cursor-pointer';
+                    headerDiv.style.userSelect = 'none';
+                    headerDiv.innerHTML = `
+                        <h6 class="mb-0">
+                            <i class="fa fa-chevron-right mr-2 transition-transform" style="transition: transform 0.2s;"></i>
+                            <strong>${group.count} Goroutines</strong> in state [${group.state}]
+                        </h6>
+                        <span class="badge badge-primary">${group.count}</span>
+                    `;
+
+                    const bodyDiv = document.createElement('div');
+                    bodyDiv.className = 'card-body d-none';
+                    bodyDiv.innerHTML = `
+                        <p class="text-muted small mb-2">Individual Goroutines: ${group.headers.join(', ')}</p>
+                        <pre style="margin-bottom: 0; padding: 10px; border-radius: 4px;">${group.callStack}</pre>
+                    `;
+
+                    headerDiv.addEventListener('click', () => {
+                        const isHidden = bodyDiv.classList.contains('d-none');
+                        const icon = headerDiv.querySelector('i');
+                        if (isHidden) {
+                            bodyDiv.classList.remove('d-none');
+                            icon.style.transform = 'rotate(90deg)';
+                        } else {
+                            bodyDiv.classList.add('d-none');
+                            icon.style.transform = 'rotate(0deg)';
+                        }
+                    });
+
+                    groupDiv.appendChild(headerDiv);
+                    groupDiv.appendChild(bodyDiv);
+                    container.appendChild(groupDiv);
+                });
+
+                if (sortedGroups.length > displayLimit) {
+                    const alertDiv = document.createElement('div');
+                    alertDiv.className = 'alert alert-warning mt-3';
+                    alertDiv.role = 'alert';
+                    alertDiv.textContent = `Showing top ${displayLimit} goroutine groups to prevent performance degradation. There are ${sortedGroups.length - displayLimit} more groups not displayed.`;
+                    container.appendChild(alertDiv);
+                }
 
             }).catch(error => {
                 console.error(error);
             });
     }
+
+    document.addEventListener('monigoThemeChanged', () => {
+        if (window.lastGoroutinesRawData && goroutinesChart) {
+            if (!goroutinesChartChartObj) {
+                goroutinesChartChartObj = echarts.init(goroutinesChart);
+            }
+            const isDark = document.body.classList.contains('dark-theme');
+            const textColor = isDark ? '#9ca3af' : '#333';
+            const gridLineColor = isDark ? '#1f2937' : '#eee';
+            const time = window.lastGoroutinesRawData.map(entry => entry.time.toLocaleTimeString());
+            const goroutines = window.lastGoroutinesRawData.map(entry => entry.value.goroutines);
+            
+            goroutinesChartChartObj.setOption({
+                title: {
+                    textStyle: { color: isDark ? '#f3f4f6' : '#333' }
+                },
+                legend: {
+                    textStyle: { color: textColor }
+                },
+                xAxis: {
+                    data: time,
+                    axisLabel: { color: textColor },
+                    axisLine: { lineStyle: { color: gridLineColor } }
+                },
+                yAxis: {
+                    axisLabel: { color: textColor },
+                    splitLine: { lineStyle: { color: gridLineColor } }
+                }
+            });
+        }
+    });
 });

--- a/static/js/historycharts.js
+++ b/static/js/historycharts.js
@@ -49,23 +49,12 @@ document.addEventListener('DOMContentLoaded', () => {
         return fetch(url, options);
     }
 
-    const refreshHtml = `
-        <div class="loader-container mt-3">
-            <div class="bouncing-dots">
-                <div class="dot"></div>
-                <div class="dot"></div>
-                <div class="dot"></div>
-            </div>
-        </div>`;
-
     const elements = {
         cpuUsageChart: document.getElementById('cpu-usage-chart'),
         goroutinesChart: document.getElementById('goroutines-chart'),
         loadMemoryChart: document.getElementById('load-memory-chart'),
         healthChart: document.getElementById('health-chart')
     };
-
-    Object.values(elements).forEach(el => el && (el.innerHTML = refreshHtml));
 
     // Function to get the local ISO string with timezone offset
     function toLocalISOString(date) {
@@ -151,18 +140,22 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
 
                 if (metricName == "health") {
+                    window.lastHealthData = rawData;
                     renderHealthChart(rawData);
                 }
 
                 if (metricName == "cpu-usage") {
+                    window.lastCpuData = rawData;
                     renderCpuUsageChart(rawData);
                 }
 
                 if (metricName == "goroutines") {
+                    window.lastGoroutinesData = rawData;
                     renderGoroutinesChart(rawData);
                 }
 
                 if (metricName == "load-memory") {
+                    window.lastLoadMemoryData = rawData;
                     renderLoadMemoryChart(rawData);
                 }
             })
@@ -172,22 +165,30 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function renderHealthChart(data) {
+        const isDark = document.body.classList.contains('dark-theme');
+        const textColor = isDark ? '#9ca3af' : '#333';
+        const titleColor = isDark ? '#f3f4f6' : '#333';
+        const gridLineColor = isDark ? '#1f2937' : '#eee';
+
         const healthChart = echarts.init(elements.healthChart);
-        const time = data.map(entry => entry.time);
+        const time = data.map(entry => new Date(entry.time).toLocaleTimeString());
         const serviceHealthPercent = data.map(entry => entry.value.service_health_percent);
         const systemHealthPercent = data.map(entry => entry.value.system_health_percent);
 
         const option = {
+            backgroundColor: 'transparent',
             title: {
                 text: 'Health Metrics',
-                left: 'center'
+                left: 'center',
+                textStyle: { color: titleColor }
             },
             tooltip: {
                 trigger: 'axis'
             },
             legend: {
                 data: ['Service Health', 'System Health'],
-                top: 30
+                top: 30,
+                textStyle: { color: textColor }
             },
             grid: {
                 left: '3%',
@@ -198,21 +199,27 @@ document.addEventListener('DOMContentLoaded', () => {
             xAxis: {
                 type: 'category',
                 boundaryGap: false,
-                data: time
+                data: time,
+                axisLabel: { color: textColor },
+                axisLine: { lineStyle: { color: gridLineColor } }
             },
             yAxis: {
-                type: 'value'
+                type: 'value',
+                axisLabel: { color: textColor },
+                splitLine: { lineStyle: { color: gridLineColor } }
             },
             series: [
                 {
                     name: 'Service Health',
                     type: 'line',
-                    data: serviceHealthPercent
+                    data: serviceHealthPercent,
+                    itemStyle: { color: '#10b981' }
                 },
                 {
                     name: 'System Health',
                     type: 'line',
-                    data: systemHealthPercent
+                    data: systemHealthPercent,
+                    itemStyle: { color: '#3b82f6' }
                 }
             ]
         };
@@ -221,23 +228,31 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function renderCpuUsageChart(data) {
+        const isDark = document.body.classList.contains('dark-theme');
+        const textColor = isDark ? '#9ca3af' : '#333';
+        const titleColor = isDark ? '#f3f4f6' : '#333';
+        const gridLineColor = isDark ? '#1f2937' : '#eee';
+
         const cpuUsageChart = echarts.init(elements.cpuUsageChart);
-        const time = data.map(entry => entry.time);
+        const time = data.map(entry => new Date(entry.time).toLocaleTimeString());
         const totalCores = data.map(entry => entry.value.total_cores);
         const coresUsedByService = data.map(entry => entry.value.cores_used_by_service);
         const coresUsedBySystem = data.map(entry => entry.value.cores_used_by_system);
 
         const option = {
+            backgroundColor: 'transparent',
             title: {
                 text: 'CPU Usage Metrics',
-                left: 'center'
+                left: 'center',
+                textStyle: { color: titleColor }
             },
             tooltip: {
                 trigger: 'axis'
             },
             legend: {
                 data: ['Total Cores', 'Cores Used by Service', 'Cores Used by System'],
-                top: 30
+                top: 30,
+                textStyle: { color: textColor }
             },
             grid: {
                 left: '3%',
@@ -248,26 +263,33 @@ document.addEventListener('DOMContentLoaded', () => {
             xAxis: {
                 type: 'category',
                 boundaryGap: false,
-                data: time
+                data: time,
+                axisLabel: { color: textColor },
+                axisLine: { lineStyle: { color: gridLineColor } }
             },
             yAxis: {
-                type: 'value'
+                type: 'value',
+                axisLabel: { color: textColor },
+                splitLine: { lineStyle: { color: gridLineColor } }
             },
             series: [
                 {
                     name: 'Total Cores',
                     type: 'line',
-                    data: totalCores
+                    data: totalCores,
+                    itemStyle: { color: '#ff5c35' }
                 },
                 {
                     name: 'Cores Used by Service',
                     type: 'line',
-                    data: coresUsedByService
+                    data: coresUsedByService,
+                    itemStyle: { color: '#00A1E4' }
                 },
                 {
                     name: 'Cores Used by System',
                     type: 'line',
-                    data: coresUsedBySystem
+                    data: coresUsedBySystem,
+                    itemStyle: { color: '#FF6F61' }
                 }
             ]
         };
@@ -276,21 +298,29 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function renderGoroutinesChart(data) {
+        const isDark = document.body.classList.contains('dark-theme');
+        const textColor = isDark ? '#9ca3af' : '#333';
+        const titleColor = isDark ? '#f3f4f6' : '#333';
+        const gridLineColor = isDark ? '#1f2937' : '#eee';
+
         const goroutinesChart = echarts.init(elements.goroutinesChart);
-        const time = data.map(entry => entry.time);
+        const time = data.map(entry => new Date(entry.time).toLocaleTimeString());
         const goroutines = data.map(entry => entry.value.goroutines);
 
         const option = {
+            backgroundColor: 'transparent',
             title: {
                 text: 'Goroutines Metrics',
-                left: 'center'
+                left: 'center',
+                textStyle: { color: titleColor }
             },
             tooltip: {
                 trigger: 'axis'
             },
             legend: {
                 data: ['Goroutines'],
-                top: 30
+                top: 30,
+                textStyle: { color: textColor }
             },
             grid: {
                 left: '3%',
@@ -301,16 +331,21 @@ document.addEventListener('DOMContentLoaded', () => {
             xAxis: {
                 type: 'category',
                 boundaryGap: false,
-                data: time
+                data: time,
+                axisLabel: { color: textColor },
+                axisLine: { lineStyle: { color: gridLineColor } }
             },
             yAxis: {
-                type: 'value'
+                type: 'value',
+                axisLabel: { color: textColor },
+                splitLine: { lineStyle: { color: gridLineColor } }
             },
             series: [
                 {
                     name: 'Goroutines',
                     type: 'line',
-                    data: goroutines
+                    data: goroutines,
+                    itemStyle: { color: '#ff5c35' }
                 }
             ]
         };
@@ -319,8 +354,13 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function renderLoadMemoryChart(data) {
+        const isDark = document.body.classList.contains('dark-theme');
+        const textColor = isDark ? '#9ca3af' : '#333';
+        const titleColor = isDark ? '#f3f4f6' : '#333';
+        const gridLineColor = isDark ? '#1f2937' : '#eee';
+
         const loadMemoryChart = echarts.init(elements.loadMemoryChart);
-        const time = data.map(entry => entry.time);
+        const time = data.map(entry => new Date(entry.time).toLocaleTimeString());
         const overallLoadOfService = data.map(entry => entry.value.overall_load_of_service);
         const serviceCpuLoad = data.map(entry => entry.value.service_cpu_load);
         const serviceMemoryLoad = data.map(entry => entry.value.service_memory_load);
@@ -328,17 +368,20 @@ document.addEventListener('DOMContentLoaded', () => {
         const systemMemoryLoad = data.map(entry => entry.value.system_memory_load);
 
         const option = {
+            backgroundColor: 'transparent',
             title: {
                 text: 'Load Memory Metrics',
                 left: 'center',
-                padding: [0, 0, 10, 0]
+                padding: [0, 0, 10, 0],
+                textStyle: { color: titleColor }
             },
             tooltip: {
                 trigger: 'axis'
             },
             legend: {
                 data: ['Overall Load of Service', 'Service CPU Load', 'Service Memory Load', 'System CPU Load', 'System Memory Load'],
-                top: 10
+                top: 30,
+                textStyle: { color: textColor }
             },
             grid: {
                 left: '3%',
@@ -349,10 +392,14 @@ document.addEventListener('DOMContentLoaded', () => {
             xAxis: {
                 type: 'category',
                 boundaryGap: false,
-                data: time
+                data: time,
+                axisLabel: { color: textColor },
+                axisLine: { lineStyle: { color: gridLineColor } }
             },
             yAxis: {
-                type: 'value'
+                type: 'value',
+                axisLabel: { color: textColor },
+                splitLine: { lineStyle: { color: gridLineColor } }
             },
             series: [
                 {
@@ -400,5 +447,10 @@ document.addEventListener('DOMContentLoaded', () => {
     updateHistoryChart("cpu-usage");
     updateHistoryChart("goroutines");
     updateHistoryChart("load-memory");
-    updateHistoryChart("health");
+    document.addEventListener('monigoThemeChanged', () => {
+        if (window.lastHealthData) renderHealthChart(window.lastHealthData);
+        if (window.lastCpuData) renderCpuUsageChart(window.lastCpuData);
+        if (window.lastGoroutinesData) renderGoroutinesChart(window.lastGoroutinesData);
+        if (window.lastLoadMemoryData) renderLoadMemoryChart(window.lastLoadMemoryData);
+    });
 });

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -106,7 +106,74 @@ document.addEventListener('DOMContentLoaded', () => {
         )
     };
 
-    Object.values(elements).forEach((el) => el && (el.innerHTML = refreshHtml));
+    function setInitialLoadState() {
+        const textElements = {
+            goroutines: ['Go Routines:', 'Number of goroutines that are currently running'],
+            serviceLoad: ['Load:', 'The load average of the system'],
+            cores: ['Cores:', 'Number of CPU cores'],
+            memory: ['Memory:', 'Memory used by the service'],
+            cpuUsage: ['CPU Usage:', 'CPU usage of the service'],
+            uptime: ['Uptime:', 'Uptime of the service']
+        };
+
+        for (const [id, [label, info]] of Object.entries(textElements)) {
+            const el = elements[id];
+            if (el) {
+                el.innerHTML = `
+                    <div>
+                        <p class="mb-2 text-muted">${label} <span class="info-icon" data-tooltip="${info}">i</span></p>
+                        <h4 class="skeleton-text animate-pulse text-muted">Connecting...</h4>
+                    </div>`;
+            }
+        }
+
+        const sName = document.getElementById('service_name');
+        if (sName) {
+            sName.innerHTML = `
+                <div class="mt-1">
+                    <p class="mb-2 text-muted">Service Name:</p>
+                    <h4 class="skeleton-text animate-pulse text-muted">Connecting...</h4>
+                </div>`;
+        }
+        const gVer = document.getElementById('go_version');
+        if (gVer) {
+            gVer.innerHTML = `
+                <div class="mt-1">
+                    <p class="mb-2 text-muted">Go Version:</p>
+                    <h4 class="skeleton-text animate-pulse text-muted">Connecting...</h4>
+                </div>`;
+        }
+        const sStart = document.getElementById('service_start_time');
+        if (sStart) {
+            sStart.innerHTML = `
+                <div class="mt-1">
+                    <p class="mb-2 text-muted">Service Start Time:</p>
+                    <h4 class="skeleton-text animate-pulse text-muted">Connecting...</h4>
+                </div>`;
+        }
+        const pId = document.getElementById('process_id');
+        if (pId) {
+            pId.innerHTML = `
+                <div class="mt-1">
+                    <p class="mb-2 text-muted">Process ID:</p>
+                    <h4 class="skeleton-text animate-pulse text-muted">Connecting...</h4>
+                </div>`;
+        }
+
+        if (elements.serviceHealthTag) {
+            elements.serviceHealthTag.innerHTML = `<span class="badge badge-warning text-muted small py-1 px-2">Service Health: Awaiting...</span>`;
+        }
+        if (elements.systemHealthTag) {
+            elements.systemHealthTag.innerHTML = `<span class="badge badge-warning text-muted small py-1 px-2">System Health: Awaiting...</span>`;
+        }
+
+        // Modal detail buttons get a clean textual connecting message
+        if (elements.memoryDetailButton) elements.memoryDetailButton.innerHTML = '<div class="text-center p-3 text-muted">Awaiting connection...</div>';
+        if (elements.coreUsageDetailButton) elements.coreUsageDetailButton.innerHTML = '<div class="text-center p-3 text-muted">Awaiting connection...</div>';
+        if (elements.loadUsageDetailButton) elements.loadUsageDetailButton.innerHTML = '<div class="text-center p-3 text-muted">Awaiting connection...</div>';
+    }
+
+    setInitialLoadState();
 
     if (GOROUTINES_PAGE) {
         fetchServiceInfo();
@@ -269,6 +336,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     health
                 } = data;
 
+                window.lastMetricsData = data;
                 updateGauge('g1', health);
                 updateElement(
                     elements.goroutines,
@@ -411,6 +479,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // KB
     function renderCharts(data) {
+        const isDark = document.body.classList.contains('dark-theme');
+        const textColor = isDark ? '#9ca3af' : '#333';
+        const titleColor = isDark ? '#f3f4f6' : '#333';
+        const gridLineColor = isDark ? '#1f2937' : '#eee';
+
         const charts = {
             loadChart: echarts.init(elements.loadChart),
             cpuChart: echarts.init(elements.cpuChart),
@@ -421,7 +494,8 @@ document.addEventListener('DOMContentLoaded', () => {
         Object.values(charts).forEach((chart) =>
             chart.setOption({
                 title: {
-                    text: 'Loading...'
+                    text: 'Loading...',
+                    textStyle: { color: titleColor }
                 },
                 tooltip: {}
             })
@@ -431,8 +505,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
         // Load Chart
         charts.loadChart.setOption({
+            backgroundColor: 'transparent',
             title: {
-                text: 'Load Statistics'
+                text: 'Load Statistics',
+                textStyle: { color: titleColor }
             },
             tooltip: {
                 trigger: 'axis',
@@ -461,11 +537,15 @@ document.addEventListener('DOMContentLoaded', () => {
                     'Total CPU Load',
                     'Service Memory Load',
                     'System Memory Load'
-                ]
+                ],
+                axisLabel: { color: textColor },
+                axisLine: { lineStyle: { color: gridLineColor } }
             },
             yAxis: {
                 type: 'value',
-                max: 100
+                max: 100,
+                axisLabel: { color: textColor },
+                splitLine: { lineStyle: { color: gridLineColor } }
             },
             series: [
                 {
@@ -480,10 +560,10 @@ document.addEventListener('DOMContentLoaded', () => {
                     itemStyle: {
                         color: (params) => {
                             const value = params.value;
-                            if (value > 90) return 'red';
-                            if (value > 80) return 'orange';
-                            if (value > 50) return 'yellow';
-                            return 'green';
+                            if (value > 90) return '#ef4444';
+                            if (value > 80) return '#f97316';
+                            if (value > 50) return '#eab308';
+                            return '#10b981';
                         }
                     },
                     emphasis: {
@@ -499,8 +579,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
         // CPU Chart
         charts.cpuChart.setOption({
+            backgroundColor: 'transparent',
             title: {
-                text: 'CPU Statistics'
+                text: 'CPU Statistics',
+                textStyle: { color: titleColor }
             },
             tooltip: {
                 trigger: 'item',
@@ -510,6 +592,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 orient: 'horizontal',
                 center: 0,
                 padding: [30, 0, 0, 0],
+                textStyle: { color: textColor },
                 data: [
                     {
                         name: 'Cores Used by Service',
@@ -540,6 +623,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     type: 'pie',
                     radius: '55%',
                     center: ['50%', '60%'],
+                    label: { color: textColor },
                     data: [
                         {
                             value: cpu_statistics.cores_used_by_service,
@@ -570,19 +654,22 @@ document.addEventListener('DOMContentLoaded', () => {
 
         // Memory Pie Chart
         charts.memoryPieChart.setOption({
+            backgroundColor: 'transparent',
             title: {
-                text: 'Memory Distribution'
+                text: 'Memory Distribution',
+                textStyle: { color: titleColor }
             },
             tooltip: {
                 trigger: 'item',
                 formatter: function (params) {
-                    return `${params.seriesName}<br/>${params.name}: ${params.value} (${params.percent}%) []`;
+                    return `${params.seriesName}<br/>${params.name}: ${params.value} (${params.percent}%)`;
                 }
             },
             legend: {
                 orient: 'horizontal',
                 center: 0,
                 padding: [40, 0, 0, 0],
+                textStyle: { color: textColor },
                 data: [
                     'Memory Used by Service',
                     'Memory Used by System',
@@ -595,6 +682,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     type: 'pie',
                     radius: '55%',
                     center: ['50%', '60%'],
+                    label: { color: textColor },
                     data: [
                         {
                             value: parseFloat(
@@ -647,8 +735,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
         // Heap Usage Chart
         charts.heapUsageChart.setOption({
+            backgroundColor: 'transparent',
             title: {
-                text: 'Heap Memory Usage'
+                text: 'Heap Memory Usage',
+                textStyle: { color: titleColor }
             },
             tooltip: {},
             xAxis: {
@@ -659,11 +749,16 @@ document.addEventListener('DOMContentLoaded', () => {
                     'HeapIdle',
                     'HeapInuse',
                     'HeapReleased'
-                ]
+                ],
+                axisLabel: { color: textColor },
+                axisLine: { lineStyle: { color: gridLineColor } }
             },
             yAxis: {
                 type: 'value',
-                name: 'MB'
+                name: 'MB',
+                nameTextStyle: { color: textColor },
+                axisLabel: { color: textColor },
+                splitLine: { lineStyle: { color: gridLineColor } }
             },
             series: [
                 {
@@ -675,7 +770,8 @@ document.addEventListener('DOMContentLoaded', () => {
                         values[2],
                         values[3],
                         values[4]
-                    ]
+                    ],
+                    itemStyle: { color: '#00A1E4' }
                 }
             ]
         });
@@ -812,35 +908,47 @@ document.addEventListener('DOMContentLoaded', () => {
                     });
                 }
 
+                const isDark = document.body.classList.contains('dark-theme');
+                const textColor = isDark ? '#9ca3af' : '#333';
+                const titleColor = isDark ? '#f3f4f6' : '#333';
+                const gridLineColor = isDark ? '#1f2937' : '#eee';
+
                 chart.setOption({
+                    backgroundColor: 'transparent',
                     title: {
                         text: getMetricTitle(metricName),
-                        left: 'center'
+                        left: 'center',
+                        textStyle: { color: titleColor }
                     },
                     tooltip: {
                         trigger: 'axis'
                     },
                     legend: {
                         top: 30,
-                        data: Object.keys(seriesData)
+                        data: Object.keys(seriesData),
+                        textStyle: { color: textColor }
                     },
                     xAxis: {
                         type: 'category',
                         boundaryGap: false,
                         data: rawData.map((d) => d.time.toLocaleString()),
                         axisLabel: {
+                            color: textColor,
                             formatter: function (value) {
                                 return value.split(' ')[1]; // Show only time
                             }
-                        }
+                        },
+                        axisLine: { lineStyle: { color: gridLineColor } }
                     },
                     yAxis: {
                         type: 'value',
                         axisLabel: {
+                            color: textColor,
                             formatter: function (value) {
                                 return formatYAxisLabel(metricName, value);
                             }
-                        }
+                        },
+                        splitLine: { lineStyle: { color: gridLineColor } }
                     },
                     series: series
                 });
@@ -928,8 +1036,6 @@ document.addEventListener('DOMContentLoaded', () => {
         const iconSysMsg = health.system_health.icon_msg;
         const iconServMsg = health.service_health.icon_msg;
         const gauge = document.getElementById(gaugeId);
-        const gaugeText = gauge.querySelector('text'); // Correct typo here
-        gaugeText.textContent = `${srevPercentage}%`;
 
         if (elements.healthMessage.textContent === '') {
             elements.healthMessage.textContent = health.service_health.message;
@@ -961,19 +1067,29 @@ document.addEventListener('DOMContentLoaded', () => {
         `;
         }
 
-        // Reset the --o property to 0 to restart the animation
-        gauge.style.setProperty('--o', 0);
+        // Render high-fidelity SVG progress ring
+        const circ = 2 * Math.PI * 40;
+        const offset = circ - (srevPercentage / 100) * circ;
+        const isDark = document.body.classList.contains('dark-theme');
+        const bgStroke = isDark ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.1)';
 
-        // Trigger a reflow to reset the animation (forces a repaint)
-        void gauge.offsetWidth;
-
-        // Set the custom properties for the gauge
-        gauge.style.setProperty('--fill-percentage', srevPercentage); // Use percentage for fill
-        gauge.style.setProperty('--fill-color', fillColorServ); // Use color for fill
-
-        // Now update --o to the target percentage to animate
-        gauge.style.setProperty('--o', srevPercentage);
+        gauge.innerHTML = `
+            <svg class="radial-ring" viewBox="0 0 100 100" style="width: 120px; height: 120px; margin: 0 auto; display: block;">
+                <circle cx="50" cy="50" r="40" fill="transparent" stroke="${bgStroke}" stroke-width="8"></circle>
+                <circle cx="50" cy="50" r="40" fill="transparent" stroke="${fillColorServ}" stroke-width="8" 
+                    stroke-dasharray="${circ}" stroke-dashoffset="${offset}" stroke-linecap="round" 
+                    transform="rotate(-90 50 50)" style="transition: stroke-dashoffset 0.8s ease-in-out;"></circle>
+                <text x="50" y="56" text-anchor="middle" font-size="16" font-weight="bold" fill="${fillColorServ}">${srevPercentage}%</text>
+            </svg>
+        `;
     }
+
+    document.addEventListener('monigoThemeChanged', () => {
+        if (window.lastMetricsData) {
+            renderCharts(window.lastMetricsData);
+            updateGauge('g1', window.lastMetricsData.health);
+        }
+    });
 });
 
 function getDlBtn(id) {

--- a/static/js/reports.js
+++ b/static/js/reports.js
@@ -178,7 +178,8 @@ document.addEventListener('DOMContentLoaded', () => {
         const tableElement = document.createElement('table');
         tableElement.classList.add('data-table', 'table', 'mb-0', 'tbl-server-info');
         const thead = document.createElement('thead');
-        thead.classList.add('bg-white', 'text-uppercase');
+        const isDark = document.body.classList.contains('dark-theme');
+        thead.classList.add(isDark ? 'bg-dark' : 'bg-white', 'text-uppercase');
         const tbody = document.createElement('tbody');
         tbody.classList.add('ligth-body');
         const directHeaders = data.length > 0 ? Object.keys(data[0]).filter(header => header !== 'value') : [];


### PR DESCRIPTION
Partially addresses #32. Third of three PRs tracked by #47. Independent of #48 and #49 — touches only `static/`.

Three of the problems listed in #32, addressed without changing the underlying stack (Bootstrap and Font Awesome stay where they are).

## Dark mode

A toggle is injected into the navbar on every page that loads `common.js` — dashboard, goroutines, reports, function metrics. The choice persists in `localStorage` under `monigo-theme`, so it survives navigation and reloads, and it is applied synchronously before charts initialise, which avoids a light-to-dark flash on load.

ECharts renders to canvas and cannot inherit CSS, so chart text, axes, gridlines, and legends read their colours from the active theme at render time. A `monigoThemeChanged` event re-renders them on toggle rather than requiring a refresh; the dashboard, goroutines, and history pages all listen for it.

## Loading states

Every metric card previously rendered a bare refresh icon until the first poll returned, which is indistinguishable from a hung dashboard. Cards now show a labelled skeleton — `Go Routines: Connecting...` — so an unreachable MoniGo server is legible as such, and chart containers carry a spinner with the same message.

The health gauge placeholder was a `60x25` viewBox containing the literal text `...`, which rendered as a stretched ellipsis. It is now a proper radial ring showing `--%` until real data arrives.

## Grouped goroutine stacks

The stack view listed every goroutine individually, so an application with hundreds of goroutines produced hundreds of near-identical entries. Identical stacks are now grouped (ignoring the goroutine ID and state line), sorted by count descending, and capped at 50 groups so a pathological process cannot lock up the page.

## Smaller fixes

- The health indicator only ever *added* a state class, so a service recovering from unhealthy kept both `healthy` and `unhealthy`. It now clears the opposite class.
- Element lookups in `common.js` are nil-checked — it loads on pages that have no health indicator, where the old code threw.
- Report table headers were hardcoded `bg-white`, unreadable in dark mode; they now follow the theme.
- Chart severity colours move from CSS keywords (`red`, `yellow`) to palette hex values.
- Removed a stray `[]` from the memory-distribution tooltip formatter.

## Verification

Booted the example app against this branch and stepped through both themes on the dashboard and goroutines pages: charts recolour on toggle, the theme persists across navigation, and there are no console errors. All JS files pass `node --check`.

No Go files are touched, so `go test`/`go vet` are unaffected by this PR.

## Scope

Issue #32 stays open after this lands. The design-token system, typography scale, component unification, mobile-first layouts, and the accessibility work (ARIA, focus management, keyboard nav, contrast auditing) described there are all still open. This covers dark mode, loading and empty states, and one concrete visual-hierarchy problem.

