### PR TITLE
feat: detect leaked goroutines from stale blocks and growing call stacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `BasicAuthMiddleware` now sends a `WWW-Authenticate` challenge when a request carries no credentials at all
 
 ### Fixed
+- **Silently truncated goroutine dumps**: `CollectGoRoutinesInfo` used a fixed 1 MB buffer with a single `runtime.Stack` call. `runtime.Stack` truncates without reporting it, so an application with thousands of goroutines got a clipped trace and undercounted -- precisely the situation goroutine leak detection needs to be accurate in. It now grows the buffer and retries, capped at 64 MB
 - **Inverted health score**: `calculateServiceHealth` clamped the score to `100` -- the best possible value -- when usage exceeded every threshold, so a fully degraded service reported as healthy. It now returns `0`, matching `calculateSystemHealth`
 - **Unbounded memory growth**: `InMemoryStorage.InsertRows` ignored the retention period and never evicted, so `WithStorageType("memory")` grew for the life of the process
 - **`WithStorageType` had no effect**: the storage singleton was initialised by `SetDataPointsSyncFrequency` before `SetStorageType` was applied, so `"memory"` silently fell through to disk
@@ -26,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `registry.GetAll()` documented a snapshot copy but shared the `Labels` map with the live registry
 
 ### Added
+- Goroutine leak detection: every collection cycle evaluates all goroutine stacks for stale goroutines (blocked past a threshold, default 24h, configurable via `WithStaleGoroutineThreshold`) and for call stacks growing monotonically across the last 5 cycles. The verdict is carried on `GoRoutinesStatistic.LeakReport` and `ServiceStats.GoroutineLeakReport`, surfaced as a warning panel on the Go Routines Stats page, and raises the alert webhook when configured
+- `core.AnalyzeGoroutineLeaks()`, `core.SetStaleGoroutineThreshold()`, `core.GetStaleGoroutineThreshold()`, and `core.ResetLeakDetectionState()`
 - Health breach webhook alerts via `WithAlertWebhook(url)` -- an opt-in `POST` fired when the system or service health score drops below 70. Dispatch is off the collection path, requests time out after 10 seconds, and deliveries are rate limited to one per 5 minutes across both alert types. `Build()` rejects a URL that is not `http://` or `https://`
 - `common.GetServiceName()` -- accessor for the configured service name
 - `core.GetThresholds()` -- thread-safe accessor for the configured health thresholds

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ m := monigo.NewBuilder().
     WithMaxMemoryUsage(90).                 // Health threshold (default: 95%)
     WithMaxGoRoutines(500).                 // Health threshold (default: 100)
     WithAlertWebhook("https://...").        // Health breach webhook (default: off)
+    WithStaleGoroutineThreshold(24*time.Hour). // Stale goroutine cutoff (default: 24h)
     WithHeadless(false).                    // true = no dashboard (default: false)
     WithTimeZone("UTC").                    // Timezone (default: "Local")
     WithLogLevel(slog.LevelInfo).           // Log level
@@ -137,6 +138,74 @@ minimum of 5 minutes separates deliveries so a flapping service cannot emit an a
 on every tick. Delivery failures are logged and otherwise ignored.
 
 `Build()` rejects a webhook URL that is not `http://` or `https://`.
+
+### Goroutine Leak Detection
+
+Every metrics collection cycle captures all goroutine stacks and evaluates them for
+two independent leak signals. The verdict appears on the Go Routines Stats page and
+in the `go-routines-stats` API response, and raises the alert webhook if one is
+configured.
+
+**Stale goroutines.** The Go runtime stamps a block duration into each goroutine's
+stack header once it has been parked for over a minute:
+
+```
+goroutine 21 [chan receive, 47 minutes]:
+```
+
+Any goroutine blocked at or beyond the threshold is reported as stale. The default
+is 24h; `WithStaleGoroutineThreshold` takes any duration of 1m or more (below that
+is not representable, since the runtime reports whole minutes only).
+
+**Growing call stacks.** Goroutines are grouped by identical call stack, and the
+per-group counts are retained across the last 5 collection cycles. A group is
+flagged only if its count rose in *every* retained cycle. That rule is deliberately
+strict: a worker pool scaling up briefly, plateauing, or oscillating is not a leak,
+and a group absent from the oldest snapshot is treated as new rather than growing.
+Nothing is reported until the window is full, so a freshly started service cannot
+raise a false alarm from two data points.
+
+```go
+m := monigo.NewBuilder().
+    WithServiceName("order-service").
+    WithStaleGoroutineThreshold(6 * time.Hour).
+    WithAlertWebhook("https://hooks.slack.com/services/...").
+    Build()
+```
+
+The report is carried on the goroutine stats response:
+
+```json
+{
+  "number_of_goroutines": 456,
+  "leak_report": {
+    "total_goroutines": 456,
+    "stale_goroutines": 443,
+    "growing_groups": 1,
+    "leak_suspected": true,
+    "snapshots_retained": 5,
+    "snapshots_required": 5,
+    "stale_threshold_minutes": 360,
+    "message": "Possible goroutine leak: 443 goroutine(s) blocked for at least 6h; 1 call stack(s) growing across the last 5 snapshots (total goroutines: 456).",
+    "suspicious_groups": [
+      {
+        "signature": "a3f19c2d4e5b",
+        "state": "chan receive",
+        "count": 440,
+        "blocked_minutes": 421,
+        "growth": 100,
+        "stale": true,
+        "growing": true,
+        "call_stack": "main.worker()\n\t/app/main.go:31 +0x24\n..."
+      }
+    ]
+  }
+}
+```
+
+Detection is driven by the metrics collection cycle rather than by dashboard
+polling, so growth snapshots stay evenly spaced and a leak is caught whether or not
+anyone has a browser tab open.
 
 ## Function Tracing
 

--- a/config_builder.go
+++ b/config_builder.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/iyashjayesh/monigo/internal/logger"
 )
@@ -110,6 +111,16 @@ func (b *MonigoBuilder) WithAlertWebhook(url string) *MonigoBuilder {
 	return b
 }
 
+// WithStaleGoroutineThreshold sets how long a goroutine must stay blocked
+// before leak detection reports it as stale. Defaults to 24h when unset.
+//
+// The Go runtime reports block duration in whole minutes, so a threshold below
+// one minute cannot be represented and is rejected by Build().
+func (b *MonigoBuilder) WithStaleGoroutineThreshold(d time.Duration) *MonigoBuilder {
+	b.config.StaleGoroutineThreshold = d
+	return b
+}
+
 // WithHeadless sets whether the dashboard should be started
 func (b *MonigoBuilder) WithHeadless(headless bool) *MonigoBuilder {
 	b.config.Headless = headless
@@ -168,6 +179,12 @@ func (b *MonigoBuilder) Build() *Monigo {
 	}
 	if b.config.MaxGoRoutines < 0 {
 		panic("[MoniGo] Build() failed: MaxGoRoutines must be >= 0")
+	}
+	if b.config.StaleGoroutineThreshold < 0 {
+		panic("[MoniGo] Build() failed: StaleGoroutineThreshold must be >= 0")
+	}
+	if b.config.StaleGoroutineThreshold > 0 && b.config.StaleGoroutineThreshold < time.Minute {
+		panic("[MoniGo] Build() failed: StaleGoroutineThreshold must be at least 1m (the runtime reports block duration in whole minutes)")
 	}
 	return b.config
 }

--- a/config_builder_test.go
+++ b/config_builder_test.go
@@ -2,6 +2,7 @@ package monigo
 
 import (
 	"testing"
+	"time"
 )
 
 func TestBuilderValidBuild(t *testing.T) {
@@ -156,6 +157,39 @@ func TestBuilderAlertWebhookValidation(t *testing.T) {
 			m := NewBuilder().WithServiceName("test").WithAlertWebhook(tt.url).Build()
 			if m.AlertWebhookURL != tt.url {
 				t.Errorf("AlertWebhookURL = %q, want %q", m.AlertWebhookURL, tt.url)
+			}
+		})
+	}
+}
+
+func TestBuilderStaleGoroutineThresholdValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		threshold time.Duration
+		wantPanic bool
+	}{
+		{"unset uses default", 0, false},
+		{"24h", 24 * time.Hour, false},
+		{"exactly 1m", time.Minute, false},
+		{"below 1m is not representable", 30 * time.Second, true},
+		{"negative", -time.Hour, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				r := recover()
+				if tt.wantPanic && r == nil {
+					t.Errorf("expected Build() to panic for %v", tt.threshold)
+				}
+				if !tt.wantPanic && r != nil {
+					t.Errorf("expected Build() to accept %v, panicked with: %v", tt.threshold, r)
+				}
+			}()
+
+			m := NewBuilder().WithServiceName("test").WithStaleGoroutineThreshold(tt.threshold).Build()
+			if m.StaleGoroutineThreshold != tt.threshold {
+				t.Errorf("StaleGoroutineThreshold = %v, want %v", m.StaleGoroutineThreshold, tt.threshold)
 			}
 		})
 	}

--- a/core/core.go
+++ b/core/core.go
@@ -72,6 +72,11 @@ func GetServiceStats(_ context.Context) models.ServiceStats {
 
 	stats.Health = GetServiceHealth(&stats)
 
+	// Leak detection runs here rather than in the API handler so that growth
+	// snapshots are evenly spaced and detection does not depend on anyone
+	// having the dashboard open.
+	stats.GoroutineLeakReport = AnalyzeGoroutineLeaks()
+
 	return stats
 }
 

--- a/core/goroutine-leaks.go
+++ b/core/goroutine-leaks.go
@@ -1,0 +1,349 @@
+package core
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/iyashjayesh/monigo/common"
+	"github.com/iyashjayesh/monigo/internal/alerting"
+	"github.com/iyashjayesh/monigo/internal/logger"
+	"github.com/iyashjayesh/monigo/models"
+)
+
+const (
+	// defaultStaleThreshold is how long a goroutine must stay blocked before it
+	// is treated as stale. The runtime reports block duration in whole minutes,
+	// so anything below a minute is not expressible.
+	defaultStaleThreshold = 24 * time.Hour
+
+	// defaultSnapshotWindow is how many periodic snapshots are retained. Growth
+	// is only reported once the window is full, so a group must rise in every
+	// one of them to be flagged -- a deliberately strict rule, because a
+	// worker pool scaling up briefly is not a leak.
+	defaultSnapshotWindow = 5
+
+	// maxSuspiciousGroups caps how many offending groups a report carries, so a
+	// pathological process cannot produce an unbounded API response.
+	maxSuspiciousGroups = 20
+)
+
+// goroutineHeaderPattern matches the header line the runtime writes for each
+// goroutine, capturing the id, the wait reason, and the optional block duration:
+//
+//	goroutine 21 [chan receive]:
+//	goroutine 21 [chan receive, 47 minutes]:
+//	goroutine 1 [running]:
+//
+// The duration is only present once the runtime considers a goroutine blocked
+// long enough to be worth reporting (see runtime/traceback.go).
+var goroutineHeaderPattern = regexp.MustCompile(`^goroutine (\d+) \[([^,\]]+)(?:, (\d+) minutes)?\]:`)
+
+var (
+	leakMu sync.RWMutex
+	// staleThreshold is the configured stale cutoff.
+	staleThreshold = defaultStaleThreshold
+	// snapshotWindow is the number of snapshots growth is computed across.
+	snapshotWindow = defaultSnapshotWindow
+	// snapshots holds per-signature counts, oldest first, at most
+	// snapshotWindow entries. Only the periodic collector appends to it.
+	snapshots []map[string]int
+)
+
+// SetStaleGoroutineThreshold configures how long a goroutine must remain
+// blocked before it is reported as stale. A non-positive value restores the
+// default of 24h.
+func SetStaleGoroutineThreshold(d time.Duration) {
+	leakMu.Lock()
+	defer leakMu.Unlock()
+	if d <= 0 {
+		staleThreshold = defaultStaleThreshold
+		return
+	}
+	staleThreshold = d
+}
+
+// GetStaleGoroutineThreshold returns the configured stale cutoff.
+func GetStaleGoroutineThreshold() time.Duration {
+	leakMu.RLock()
+	defer leakMu.RUnlock()
+	return staleThreshold
+}
+
+// parseGoroutineHeader extracts the id, wait reason, and block duration from a
+// goroutine block's first line. ok is false when the line is not a header.
+func parseGoroutineHeader(block string) (id int, state string, blockedMinutes int, ok bool) {
+	header := block
+	if idx := strings.IndexByte(block, '\n'); idx >= 0 {
+		header = block[:idx]
+	}
+
+	m := goroutineHeaderPattern.FindStringSubmatch(strings.TrimSpace(header))
+	if m == nil {
+		return 0, "", 0, false
+	}
+
+	id, err := strconv.Atoi(m[1])
+	if err != nil {
+		return 0, "", 0, false
+	}
+	if m[3] != "" {
+		// A malformed duration is not worth discarding the goroutine over.
+		blockedMinutes, _ = strconv.Atoi(m[3])
+	}
+	return id, m[2], blockedMinutes, true
+}
+
+// callStackOf returns a goroutine block with its header line removed, so that
+// two goroutines sitting at the same place in the program compare equal
+// regardless of their ids or how long they have been waiting.
+func callStackOf(block string) string {
+	if idx := strings.IndexByte(block, '\n'); idx >= 0 {
+		return strings.TrimRight(block[idx+1:], "\n")
+	}
+	return ""
+}
+
+// signatureOf hashes a call stack into a short, stable identifier. The full
+// stack can run to kilobytes, and it is carried separately on the group.
+func signatureOf(callStack string) string {
+	sum := sha256.Sum256([]byte(callStack))
+	return hex.EncodeToString(sum[:6])
+}
+
+// groupGoroutines collapses raw goroutine blocks into one group per distinct
+// call stack, carrying the longest observed block duration for each.
+func groupGoroutines(blocks []string) map[string]*models.GoroutineGroup {
+	groups := make(map[string]*models.GoroutineGroup)
+
+	for _, block := range blocks {
+		_, state, blockedMinutes, ok := parseGoroutineHeader(block)
+		if !ok {
+			continue
+		}
+
+		callStack := callStackOf(block)
+		sig := signatureOf(callStack)
+
+		g, seen := groups[sig]
+		if !seen {
+			g = &models.GoroutineGroup{
+				Signature: sig,
+				State:     state,
+				CallStack: callStack,
+			}
+			groups[sig] = g
+		}
+		g.Count++
+		if blockedMinutes > g.BlockedMinutes {
+			g.BlockedMinutes = blockedMinutes
+			// Report the state of the longest-blocked member, which is the one
+			// a developer chasing a leak cares about.
+			g.State = state
+		}
+	}
+
+	return groups
+}
+
+// recordSnapshot appends per-signature counts to the retained window, evicting
+// the oldest entry once the window is full.
+//
+// Only the periodic collector may call this. Growth is meaningless unless
+// snapshots are evenly spaced, and dashboard polling is driven by whoever
+// happens to have a browser tab open.
+func recordSnapshot(groups map[string]*models.GoroutineGroup) {
+	counts := make(map[string]int, len(groups))
+	for sig, g := range groups {
+		counts[sig] = g.Count
+	}
+
+	leakMu.Lock()
+	defer leakMu.Unlock()
+	snapshots = append(snapshots, counts)
+	if len(snapshots) > snapshotWindow {
+		snapshots = snapshots[len(snapshots)-snapshotWindow:]
+	}
+}
+
+// growthFor reports the change in a signature's count across the retained
+// window, and whether it rose at every step.
+//
+// monotonic is false unless the window is full, so a freshly started service
+// cannot report a leak from two data points.
+func growthFor(sig string) (growth int, monotonic bool) {
+	leakMu.RLock()
+	defer leakMu.RUnlock()
+
+	if len(snapshots) < snapshotWindow {
+		return 0, false
+	}
+
+	first, ok := snapshots[0][sig]
+	if !ok {
+		// Absent from the oldest snapshot: it may be genuinely new rather than
+		// growing, and treating a zero baseline as growth flags every
+		// short-lived stack.
+		return 0, false
+	}
+
+	rising := true
+	prev := first
+	for _, snap := range snapshots[1:] {
+		cur := snap[sig]
+		if cur <= prev {
+			rising = false
+		}
+		prev = cur
+	}
+
+	return prev - first, rising
+}
+
+// buildReport evaluates grouped goroutines against the stale threshold and the
+// retained growth window.
+func buildReport(total int, groups map[string]*models.GoroutineGroup) *models.GoroutineLeakReport {
+	threshold := GetStaleGoroutineThreshold()
+	thresholdMinutes := int(threshold.Minutes())
+
+	leakMu.RLock()
+	retained, required := len(snapshots), snapshotWindow
+	leakMu.RUnlock()
+
+	report := &models.GoroutineLeakReport{
+		TotalGoroutines:       total,
+		StaleThresholdMinutes: thresholdMinutes,
+		SnapshotsRetained:     retained,
+		SnapshotsRequired:     required,
+	}
+
+	var suspicious []models.GoroutineGroup
+	for sig, g := range groups {
+		entry := *g
+		entry.Growth, entry.Growing = growthFor(sig)
+		entry.Stale = thresholdMinutes > 0 && entry.BlockedMinutes >= thresholdMinutes
+
+		if entry.Stale {
+			report.StaleGoroutines += entry.Count
+		}
+		if entry.Growing {
+			report.GrowingGroups++
+		}
+		if entry.Stale || entry.Growing {
+			suspicious = append(suspicious, entry)
+		}
+	}
+
+	// Worst first: longest-blocked, then fastest-growing, then largest. The
+	// signature tie-breaker keeps ordering deterministic for equal groups.
+	sort.Slice(suspicious, func(i, j int) bool {
+		a, b := suspicious[i], suspicious[j]
+		if a.BlockedMinutes != b.BlockedMinutes {
+			return a.BlockedMinutes > b.BlockedMinutes
+		}
+		if a.Growth != b.Growth {
+			return a.Growth > b.Growth
+		}
+		if a.Count != b.Count {
+			return a.Count > b.Count
+		}
+		return a.Signature < b.Signature
+	})
+
+	if len(suspicious) > maxSuspiciousGroups {
+		suspicious = suspicious[:maxSuspiciousGroups]
+	}
+	report.SuspiciousGroups = suspicious
+	report.LeakSuspected = report.StaleGoroutines > 0 || report.GrowingGroups > 0
+	report.Message = describeReport(report, threshold)
+
+	return report
+}
+
+// describeReport renders the human-readable summary carried on the report and
+// used as the alert message.
+func describeReport(r *models.GoroutineLeakReport, threshold time.Duration) string {
+	if !r.LeakSuspected {
+		if r.SnapshotsRetained < r.SnapshotsRequired {
+			return fmt.Sprintf(
+				"No goroutine leak detected across %d goroutines. Growth tracking warming up (%d/%d snapshots).",
+				r.TotalGoroutines, r.SnapshotsRetained, r.SnapshotsRequired,
+			)
+		}
+		return fmt.Sprintf("No goroutine leak detected across %d goroutines.", r.TotalGoroutines)
+	}
+
+	var parts []string
+	if r.StaleGoroutines > 0 {
+		parts = append(parts, fmt.Sprintf(
+			"%d goroutine(s) blocked for at least %s", r.StaleGoroutines, formatThreshold(threshold),
+		))
+	}
+	if r.GrowingGroups > 0 {
+		parts = append(parts, fmt.Sprintf(
+			"%d call stack(s) growing across the last %d snapshots", r.GrowingGroups, r.SnapshotsRequired,
+		))
+	}
+	return fmt.Sprintf(
+		"Possible goroutine leak: %s (total goroutines: %d).",
+		strings.Join(parts, "; "), r.TotalGoroutines,
+	)
+}
+
+// formatThreshold renders a duration the way an operator would say it. Whole
+// hours read as hours; anything else stays in minutes rather than being rounded
+// into a wrong-looking hour count.
+func formatThreshold(d time.Duration) string {
+	if d >= time.Hour && d%time.Hour == 0 {
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	}
+	return fmt.Sprintf("%dm", int(d.Minutes()))
+}
+
+// leakReportFor evaluates already-captured goroutine blocks without recording a
+// snapshot. Used by the on-demand API path, which is driven by dashboard
+// polling and must not disturb the evenly-spaced growth history.
+func leakReportFor(blocks []string) *models.GoroutineLeakReport {
+	return buildReport(len(blocks), groupGoroutines(blocks))
+}
+
+// AnalyzeGoroutineLeaks captures every goroutine stack, records a snapshot for
+// growth tracking, and returns the resulting verdict. A suspected leak raises
+// an alert webhook if one is configured.
+//
+// This is the periodic entry point and is called from the metrics collection
+// path, so detection does not depend on anyone having the dashboard open.
+func AnalyzeGoroutineLeaks() *models.GoroutineLeakReport {
+	blocks := SplitGoroutines(captureAllStacks())
+	groups := groupGoroutines(blocks)
+
+	recordSnapshot(groups)
+
+	report := buildReport(len(blocks), groups)
+	if report.LeakSuspected {
+		logger.Log.Warn("possible goroutine leak detected",
+			"stale_goroutines", report.StaleGoroutines,
+			"growing_groups", report.GrowingGroups,
+			"total_goroutines", report.TotalGoroutines,
+		)
+		alerting.TriggerAlert(common.GetServiceName(), float64(report.TotalGoroutines),
+			"Goroutine Leak Alert: "+report.Message)
+	}
+	return report
+}
+
+// ResetLeakDetectionState clears the retained snapshot window and restores the
+// default threshold. Exported for tests and for callers restarting collection.
+func ResetLeakDetectionState() {
+	leakMu.Lock()
+	defer leakMu.Unlock()
+	snapshots = nil
+	staleThreshold = defaultStaleThreshold
+	snapshotWindow = defaultSnapshotWindow
+}

--- a/core/goroutine_leaks_test.go
+++ b/core/goroutine_leaks_test.go
@@ -1,0 +1,704 @@
+package core
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/iyashjayesh/monigo/models"
+)
+
+// block renders a goroutine block the way runtime.Stack writes it.
+func block(id int, state string, minutes int, fn string) string {
+	header := fmt.Sprintf("goroutine %d [%s]:", id, state)
+	if minutes > 0 {
+		header = fmt.Sprintf("goroutine %d [%s, %d minutes]:", id, state, minutes)
+	}
+	return header + "\n" +
+		fmt.Sprintf("main.%s(...)\n", fn) +
+		"\t/app/main.go:42 +0x1c\n" +
+		"created by main.main\n" +
+		"\t/app/main.go:17 +0x88\n"
+}
+
+func TestParseGoroutineHeader(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantID      int
+		wantState   string
+		wantMinutes int
+		wantOK      bool
+	}{
+		{"running, no duration", "goroutine 1 [running]:\nmain.main()", 1, "running", 0, true},
+		{"chan receive with duration", "goroutine 21 [chan receive, 47 minutes]:\nx()", 21, "chan receive", 47, true},
+		{"select with duration", "goroutine 9 [select, 1440 minutes]:\nx()", 9, "select", 1440, true},
+		{"IO wait", "goroutine 5 [IO wait]:\nx()", 5, "IO wait", 0, true},
+		{"semacquire", "goroutine 7 [semacquire, 3 minutes]:\nx()", 7, "semacquire", 3, true},
+		{"sync.WaitGroup.Wait", "goroutine 8 [sync.WaitGroup.Wait, 12 minutes]:\nx()", 8, "sync.WaitGroup.Wait", 12, true},
+		{"large id and duration", "goroutine 1234567 [chan send, 99999 minutes]:\nx()", 1234567, "chan send", 99999, true},
+		{"header only, no body", "goroutine 3 [sleep]:", 3, "sleep", 0, true},
+		{"not a header", "main.main()\n\t/app/main.go:9", 0, "", 0, false},
+		{"empty", "", 0, "", 0, false},
+		{"missing brackets", "goroutine 4 running:", 0, "", 0, false},
+		{"non-numeric id", "goroutine abc [running]:", 0, "", 0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id, state, minutes, ok := parseGoroutineHeader(tt.input)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !tt.wantOK {
+				return
+			}
+			if id != tt.wantID {
+				t.Errorf("id = %d, want %d", id, tt.wantID)
+			}
+			if state != tt.wantState {
+				t.Errorf("state = %q, want %q", state, tt.wantState)
+			}
+			if minutes != tt.wantMinutes {
+				t.Errorf("minutes = %d, want %d", minutes, tt.wantMinutes)
+			}
+		})
+	}
+}
+
+// The parser must handle real runtime output, not just the fixtures above.
+func TestParseGoroutineHeaderAgainstRealRuntimeOutput(t *testing.T) {
+	blocks := SplitGoroutines(captureAllStacks())
+	if len(blocks) == 0 {
+		t.Fatal("expected at least one goroutine block")
+	}
+
+	parsed := 0
+	for _, b := range blocks {
+		if _, _, _, ok := parseGoroutineHeader(b); ok {
+			parsed++
+		}
+	}
+	if parsed != len(blocks) {
+		t.Errorf("parsed %d of %d real goroutine blocks; the header format may have changed", parsed, len(blocks))
+	}
+}
+
+// Goroutines at the same place in the program group together regardless of id
+// or how long each has been waiting.
+func TestGroupGoroutinesCollapsesIdenticalStacks(t *testing.T) {
+	blocks := []string{
+		block(1, "chan receive", 0, "worker"),
+		block(2, "chan receive", 5, "worker"),
+		block(3, "chan receive", 90, "worker"),
+		block(4, "select", 0, "dispatcher"),
+	}
+
+	groups := groupGoroutines(blocks)
+	if len(groups) != 2 {
+		t.Fatalf("expected 2 groups, got %d", len(groups))
+	}
+
+	var worker, dispatcher *models.GoroutineGroup
+	for _, g := range groups {
+		if strings.Contains(g.CallStack, "worker") {
+			worker = g
+		} else {
+			dispatcher = g
+		}
+	}
+
+	if worker == nil || dispatcher == nil {
+		t.Fatal("expected one worker group and one dispatcher group")
+	}
+	if worker.Count != 3 {
+		t.Errorf("worker count = %d, want 3", worker.Count)
+	}
+	// The longest-blocked member's duration wins; that is the one worth chasing.
+	if worker.BlockedMinutes != 90 {
+		t.Errorf("worker blocked minutes = %d, want 90", worker.BlockedMinutes)
+	}
+	// ...and its state, since that is the goroutine a developer will chase.
+	if worker.State != "chan receive" {
+		t.Errorf("worker state = %q, want %q", worker.State, "chan receive")
+	}
+	if dispatcher.Count != 1 {
+		t.Errorf("dispatcher count = %d, want 1", dispatcher.Count)
+	}
+}
+
+// Blocks with no parsable header are skipped rather than counted.
+func TestGroupGoroutinesSkipsUnparsableBlocks(t *testing.T) {
+	groups := groupGoroutines([]string{
+		block(1, "chan receive", 0, "worker"),
+		"garbage without a header\n\tnot a stack",
+		"",
+	})
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(groups))
+	}
+}
+
+func TestStaleThresholdConfiguration(t *testing.T) {
+	t.Cleanup(ResetLeakDetectionState)
+
+	if got := GetStaleGoroutineThreshold(); got != defaultStaleThreshold {
+		t.Errorf("default threshold = %v, want %v", got, defaultStaleThreshold)
+	}
+
+	SetStaleGoroutineThreshold(90 * time.Minute)
+	if got := GetStaleGoroutineThreshold(); got != 90*time.Minute {
+		t.Errorf("threshold = %v, want 90m", got)
+	}
+
+	// Non-positive restores the default rather than disabling detection.
+	SetStaleGoroutineThreshold(0)
+	if got := GetStaleGoroutineThreshold(); got != defaultStaleThreshold {
+		t.Errorf("threshold after 0 = %v, want default %v", got, defaultStaleThreshold)
+	}
+	SetStaleGoroutineThreshold(-5 * time.Hour)
+	if got := GetStaleGoroutineThreshold(); got != defaultStaleThreshold {
+		t.Errorf("threshold after negative = %v, want default %v", got, defaultStaleThreshold)
+	}
+}
+
+func TestStaleDetection(t *testing.T) {
+	t.Cleanup(ResetLeakDetectionState)
+	ResetLeakDetectionState()
+	SetStaleGoroutineThreshold(60 * time.Minute)
+
+	report := leakReportFor([]string{
+		block(1, "chan receive", 59, "justUnder"), // below threshold
+		block(2, "chan receive", 60, "atExactly"), // at threshold, inclusive
+		block(3, "select", 600, "wayOver"),
+		block(4, "running", 0, "healthy"),
+	})
+
+	if report.StaleGoroutines != 2 {
+		t.Errorf("stale goroutines = %d, want 2", report.StaleGoroutines)
+	}
+	if !report.LeakSuspected {
+		t.Error("expected LeakSuspected with stale goroutines present")
+	}
+	if report.StaleThresholdMinutes != 60 {
+		t.Errorf("threshold minutes = %d, want 60", report.StaleThresholdMinutes)
+	}
+	if len(report.SuspiciousGroups) != 2 {
+		t.Fatalf("suspicious groups = %d, want 2", len(report.SuspiciousGroups))
+	}
+	// Worst first: the 600-minute group leads.
+	if report.SuspiciousGroups[0].BlockedMinutes != 600 {
+		t.Errorf("first suspicious group blocked = %d, want 600",
+			report.SuspiciousGroups[0].BlockedMinutes)
+	}
+	if !strings.Contains(report.Message, "Possible goroutine leak") {
+		t.Errorf("unexpected message: %q", report.Message)
+	}
+}
+
+func TestNoLeakReportedWhenHealthy(t *testing.T) {
+	t.Cleanup(ResetLeakDetectionState)
+	ResetLeakDetectionState()
+
+	report := leakReportFor([]string{
+		block(1, "running", 0, "a"),
+		block(2, "IO wait", 3, "b"),
+	})
+
+	if report.LeakSuspected {
+		t.Errorf("expected no leak, got message: %q", report.Message)
+	}
+	if report.StaleGoroutines != 0 || report.GrowingGroups != 0 {
+		t.Errorf("stale=%d growing=%d, want 0/0", report.StaleGoroutines, report.GrowingGroups)
+	}
+	if len(report.SuspiciousGroups) != 0 {
+		t.Errorf("expected no suspicious groups, got %d", len(report.SuspiciousGroups))
+	}
+	if !strings.Contains(report.Message, "No goroutine leak detected") {
+		t.Errorf("unexpected message: %q", report.Message)
+	}
+}
+
+// Growth must not be reported until the snapshot window is full, otherwise a
+// service that has just started reports a leak from two data points.
+func TestGrowthRequiresFullSnapshotWindow(t *testing.T) {
+	t.Cleanup(ResetLeakDetectionState)
+	ResetLeakDetectionState()
+
+	// Rising every time, but one snapshot short of the window.
+	for i := 1; i < defaultSnapshotWindow; i++ {
+		blocks := make([]string, 0, i)
+		for j := 0; j < i; j++ {
+			blocks = append(blocks, block(j+1, "chan receive", 0, "leaky"))
+		}
+		recordSnapshot(groupGoroutines(blocks))
+	}
+
+	report := leakReportFor([]string{block(1, "chan receive", 0, "leaky")})
+	if report.GrowingGroups != 0 {
+		t.Errorf("growing groups = %d, want 0 before the window is full", report.GrowingGroups)
+	}
+	if report.SnapshotsRetained >= report.SnapshotsRequired {
+		t.Errorf("retained %d of %d; expected an incomplete window",
+			report.SnapshotsRetained, report.SnapshotsRequired)
+	}
+	if !strings.Contains(report.Message, "warming up") {
+		t.Errorf("expected a warming-up message, got %q", report.Message)
+	}
+}
+
+// A stack whose count rises at every snapshot across a full window is a leak.
+func TestGrowthDetectedForMonotonicIncrease(t *testing.T) {
+	t.Cleanup(ResetLeakDetectionState)
+	ResetLeakDetectionState()
+
+	var final []string
+	for i := 1; i <= defaultSnapshotWindow; i++ {
+		blocks := make([]string, 0, i)
+		for j := 0; j < i; j++ {
+			blocks = append(blocks, block(j+1, "chan receive", 0, "leaky"))
+		}
+		recordSnapshot(groupGoroutines(blocks))
+		final = blocks
+	}
+
+	report := leakReportFor(final)
+	if report.GrowingGroups != 1 {
+		t.Fatalf("growing groups = %d, want 1", report.GrowingGroups)
+	}
+	if !report.LeakSuspected {
+		t.Error("expected LeakSuspected for a monotonically growing stack")
+	}
+
+	g := report.SuspiciousGroups[0]
+	if !g.Growing {
+		t.Error("expected the group to be marked Growing")
+	}
+	// From 1 in the oldest retained snapshot to defaultSnapshotWindow in the newest.
+	if want := defaultSnapshotWindow - 1; g.Growth != want {
+		t.Errorf("growth = %d, want %d", g.Growth, want)
+	}
+	if !strings.Contains(report.Message, "growing across the last") {
+		t.Errorf("unexpected message: %q", report.Message)
+	}
+}
+
+// A pool that scales up and back down, or holds steady, is not a leak.
+func TestGrowthNotDetectedForNonMonotonicCounts(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		counts []int
+	}{
+		{"steady", []int{3, 3, 3, 3, 3}},
+		{"spike then settle", []int{1, 5, 5, 2, 2}},
+		{"sawtooth", []int{1, 2, 1, 2, 3}},
+		{"shrinking", []int{5, 4, 3, 2, 1}},
+		{"plateau at the end", []int{1, 2, 3, 4, 4}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Cleanup(ResetLeakDetectionState)
+			ResetLeakDetectionState()
+
+			var final []string
+			for _, n := range tc.counts {
+				blocks := make([]string, 0, n)
+				for j := 0; j < n; j++ {
+					blocks = append(blocks, block(j+1, "chan receive", 0, "pool"))
+				}
+				recordSnapshot(groupGoroutines(blocks))
+				final = blocks
+			}
+
+			report := leakReportFor(final)
+			if report.GrowingGroups != 0 {
+				t.Errorf("counts %v: growing groups = %d, want 0", tc.counts, report.GrowingGroups)
+			}
+		})
+	}
+}
+
+// A stack absent from the oldest snapshot is new, not growing -- otherwise
+// every short-lived request handler is flagged.
+func TestGrowthNotDetectedForNewlyAppearedStack(t *testing.T) {
+	t.Cleanup(ResetLeakDetectionState)
+	ResetLeakDetectionState()
+
+	for i := 0; i < defaultSnapshotWindow; i++ {
+		recordSnapshot(groupGoroutines([]string{block(1, "running", 0, "existing")}))
+	}
+
+	report := leakReportFor([]string{
+		block(1, "running", 0, "existing"),
+		block(2, "chan receive", 0, "brandNew"),
+	})
+	if report.GrowingGroups != 0 {
+		t.Errorf("growing groups = %d, want 0 for a stack with no baseline", report.GrowingGroups)
+	}
+}
+
+// The retained window must not grow without bound.
+func TestSnapshotWindowIsBounded(t *testing.T) {
+	t.Cleanup(ResetLeakDetectionState)
+	ResetLeakDetectionState()
+
+	for i := 0; i < defaultSnapshotWindow*10; i++ {
+		recordSnapshot(groupGoroutines([]string{block(1, "running", 0, "x")}))
+	}
+
+	leakMu.RLock()
+	retained := len(snapshots)
+	leakMu.RUnlock()
+
+	if retained != defaultSnapshotWindow {
+		t.Errorf("retained %d snapshots, want %d", retained, defaultSnapshotWindow)
+	}
+}
+
+// The API response must stay bounded no matter how pathological the process.
+func TestSuspiciousGroupsAreCapped(t *testing.T) {
+	t.Cleanup(ResetLeakDetectionState)
+	ResetLeakDetectionState()
+	SetStaleGoroutineThreshold(time.Minute)
+
+	blocks := make([]string, 0, maxSuspiciousGroups*3)
+	for i := 0; i < maxSuspiciousGroups*3; i++ {
+		blocks = append(blocks, block(i+1, "chan receive", 60+i, fmt.Sprintf("stack%d", i)))
+	}
+
+	report := leakReportFor(blocks)
+	if len(report.SuspiciousGroups) != maxSuspiciousGroups {
+		t.Errorf("suspicious groups = %d, want the cap of %d", len(report.SuspiciousGroups), maxSuspiciousGroups)
+	}
+	// Totals must still reflect everything, not just what was returned.
+	if report.StaleGoroutines != maxSuspiciousGroups*3 {
+		t.Errorf("stale goroutines = %d, want %d", report.StaleGoroutines, maxSuspiciousGroups*3)
+	}
+}
+
+// Ordering must be deterministic so the dashboard does not reshuffle on refresh.
+func TestSuspiciousGroupOrderingIsDeterministic(t *testing.T) {
+	t.Cleanup(ResetLeakDetectionState)
+	ResetLeakDetectionState()
+	SetStaleGoroutineThreshold(time.Minute)
+
+	blocks := []string{
+		block(1, "chan receive", 10, "a"),
+		block(2, "select", 500, "b"),
+		block(3, "semacquire", 100, "c"),
+	}
+
+	var first []string
+	for i := 0; i < 20; i++ {
+		report := leakReportFor(blocks)
+		order := make([]string, 0, len(report.SuspiciousGroups))
+		for _, g := range report.SuspiciousGroups {
+			order = append(order, g.Signature)
+		}
+		if i == 0 {
+			first = order
+			continue
+		}
+		if strings.Join(order, ",") != strings.Join(first, ",") {
+			t.Fatalf("ordering changed between passes: %v vs %v", first, order)
+		}
+	}
+	// Longest-blocked leads.
+	if got := leakReportFor(blocks).SuspiciousGroups[0].BlockedMinutes; got != 500 {
+		t.Errorf("first group blocked = %d, want 500", got)
+	}
+}
+
+// Signatures identify a call stack, so they must be stable across passes and
+// distinct between different stacks.
+func TestSignatureStability(t *testing.T) {
+	a := callStackOf(block(1, "chan receive", 0, "worker"))
+	b := callStackOf(block(99, "select", 4000, "worker")) // same stack, different header
+	c := callStackOf(block(1, "chan receive", 0, "other"))
+
+	if signatureOf(a) != signatureOf(b) {
+		t.Error("expected identical signatures for the same call stack")
+	}
+	if signatureOf(a) == signatureOf(c) {
+		t.Error("expected different signatures for different call stacks")
+	}
+	if signatureOf(a) != signatureOf(a) {
+		t.Error("signature is not deterministic")
+	}
+}
+
+// AnalyzeGoroutineLeaks is called from the metrics path; concurrent calls must
+// be safe. Run under -race.
+func TestAnalyzeGoroutineLeaksConcurrent(t *testing.T) {
+	t.Cleanup(ResetLeakDetectionState)
+	ResetLeakDetectionState()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(3)
+		go func() { defer wg.Done(); AnalyzeGoroutineLeaks() }()
+		go func() { defer wg.Done(); _ = GetStaleGoroutineThreshold() }()
+		go func() { defer wg.Done(); SetStaleGoroutineThreshold(time.Hour) }()
+	}
+	wg.Wait()
+}
+
+// A real pass over the live process must produce a coherent report.
+func TestAnalyzeGoroutineLeaksAgainstLiveProcess(t *testing.T) {
+	t.Cleanup(ResetLeakDetectionState)
+	ResetLeakDetectionState()
+
+	report := AnalyzeGoroutineLeaks()
+	if report == nil {
+		t.Fatal("expected a report")
+	}
+	if report.TotalGoroutines <= 0 {
+		t.Errorf("total goroutines = %d, want > 0", report.TotalGoroutines)
+	}
+	if report.SnapshotsRetained != 1 {
+		t.Errorf("snapshots retained = %d, want 1 after one pass", report.SnapshotsRetained)
+	}
+	// The test binary has not been running for 24h, so nothing can be stale.
+	if report.StaleGoroutines != 0 {
+		t.Errorf("stale goroutines = %d, want 0 in a fresh process", report.StaleGoroutines)
+	}
+	if report.Message == "" {
+		t.Error("expected a non-empty message")
+	}
+}
+
+func TestFormatThreshold(t *testing.T) {
+	for _, tc := range []struct {
+		in   time.Duration
+		want string
+	}{
+		{24 * time.Hour, "24h"},
+		{48 * time.Hour, "48h"},
+		{90 * time.Minute, "90m"},
+		{25 * time.Hour, "25h"},
+		{time.Hour, "1h"},
+		{30 * time.Minute, "30m"},
+		{time.Minute, "1m"},
+	} {
+		if got := formatThreshold(tc.in); got != tc.want {
+			t.Errorf("formatThreshold(%v) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// End-to-end: leak real goroutines in this process and confirm the detector
+// sees them growing. This exercises the whole path -- runtime.Stack capture,
+// splitting, header parsing, grouping, snapshotting, growth analysis -- against
+// genuine runtime output rather than fixtures.
+func TestDetectsRealLeakingGoroutines(t *testing.T) {
+	t.Cleanup(ResetLeakDetectionState)
+	ResetLeakDetectionState()
+
+	// Goroutines parked on a channel nobody will ever send to: the classic leak.
+	park := make(chan struct{})
+	done := make(chan struct{})
+	var spawned sync.WaitGroup
+
+	leak := func(n int) {
+		for i := 0; i < n; i++ {
+			spawned.Add(1)
+			go func() {
+				defer spawned.Done()
+				select {
+				case <-park:
+				case <-done:
+				}
+			}()
+		}
+		// Let the runtime actually park them before capturing.
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Release every leaked goroutine on the way out, so this test does not
+	// itself leak into the rest of the package's tests.
+	t.Cleanup(func() {
+		close(done)
+		spawned.Wait()
+	})
+
+	// Leak before every snapshot, one more time than the window holds, so the
+	// retained window is full AND every step in it rose. A trailing analysis
+	// with no new goroutines would make the final step flat, which the
+	// monotonic rule correctly refuses to call a leak.
+	var report *models.GoroutineLeakReport
+	for i := 0; i < defaultSnapshotWindow+1; i++ {
+		leak(5)
+		report = AnalyzeGoroutineLeaks()
+	}
+	if report.GrowingGroups == 0 {
+		t.Fatalf("expected a growing group; report: %+v", report.Message)
+	}
+	if !report.LeakSuspected {
+		t.Error("expected LeakSuspected for genuinely leaking goroutines")
+	}
+
+	// The growing group should be the parked select, and its growth should
+	// reflect the goroutines added across the retained window.
+	var found bool
+	for _, g := range report.SuspiciousGroups {
+		if g.Growing && strings.Contains(g.CallStack, "TestDetectsRealLeakingGoroutines") {
+			found = true
+			if g.Growth <= 0 {
+				t.Errorf("growth = %d, want > 0", g.Growth)
+			}
+			if g.Count < defaultSnapshotWindow*5 {
+				t.Errorf("count = %d, want at least %d", g.Count, defaultSnapshotWindow*5)
+			}
+		}
+	}
+	if !found {
+		var stacks []string
+		for _, g := range report.SuspiciousGroups {
+			stacks = append(stacks, g.State)
+		}
+		t.Errorf("did not find the leaking stack among suspicious groups (states: %v)", stacks)
+	}
+}
+
+// A process whose goroutine count is stable must not be reported as leaking,
+// even over a full window. Guards against the detector crying wolf.
+func TestStableProcessIsNotReportedAsLeaking(t *testing.T) {
+	t.Cleanup(ResetLeakDetectionState)
+	ResetLeakDetectionState()
+
+	for i := 0; i < defaultSnapshotWindow+2; i++ {
+		AnalyzeGoroutineLeaks()
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	report := AnalyzeGoroutineLeaks()
+	if report.LeakSuspected {
+		t.Errorf("stable process reported as leaking: %s", report.Message)
+	}
+}
+
+// runtime.Stack truncates silently and reports only bytes written, so the only
+// signal of truncation is a result that exactly fills the buffer. These cases
+// cover the retry logic that replaced the old fixed 1 MB single call.
+func TestCaptureStacksGrowsUntilTheDumpFits(t *testing.T) {
+	const payloadSize = 5000
+
+	t.Run("fits on the first attempt", func(t *testing.T) {
+		calls := 0
+		dump := func(buf []byte, all bool) int {
+			calls++
+			return copy(buf, strings.Repeat("x", 10))
+		}
+		got := captureStacks(dump, 1024, 1<<20)
+		if len(got) != 10 {
+			t.Errorf("len = %d, want 10", len(got))
+		}
+		if calls != 1 {
+			t.Errorf("dump called %d times, want 1", calls)
+		}
+	})
+
+	t.Run("retries with a larger buffer until it fits", func(t *testing.T) {
+		calls := 0
+		sizes := []int{}
+		dump := func(buf []byte, all bool) int {
+			calls++
+			sizes = append(sizes, len(buf))
+			// Simulate a dump of payloadSize bytes: fills (and so appears
+			// truncated) for any buffer that cannot hold it.
+			return copy(buf, strings.Repeat("x", payloadSize))
+		}
+
+		got := captureStacks(dump, 1024, 1<<20)
+		if len(got) != payloadSize {
+			t.Errorf("len = %d, want the full %d bytes", len(got), payloadSize)
+		}
+		// 1024 -> 2048 -> 4096 -> 8192, the first that exceeds payloadSize.
+		want := []int{1024, 2048, 4096, 8192}
+		if len(sizes) != len(want) {
+			t.Fatalf("buffer sizes tried = %v, want %v", sizes, want)
+		}
+		for i := range want {
+			if sizes[i] != want[i] {
+				t.Errorf("attempt %d used %d bytes, want %d", i+1, sizes[i], want[i])
+			}
+		}
+	})
+
+	t.Run("stops doubling at the cap and accepts truncation", func(t *testing.T) {
+		calls := 0
+		dump := func(buf []byte, all bool) int {
+			calls++
+			// Never fits, whatever the buffer size.
+			for i := range buf {
+				buf[i] = 'x'
+			}
+			return len(buf)
+		}
+
+		got := captureStacks(dump, 1024, 4096)
+		if len(got) != 4096 {
+			t.Errorf("len = %d, want the capped %d", len(got), 4096)
+		}
+		// 1024, 2048, 4096 -- then the cap is reached and it gives up.
+		if calls != 3 {
+			t.Errorf("dump called %d times, want 3 before hitting the cap", calls)
+		}
+	})
+
+	t.Run("a truncating fixed buffer is what the old code did", func(t *testing.T) {
+		// Regression guard: with a single fixed call the payload would be
+		// clipped to the buffer size, undercounting goroutines.
+		dump := func(buf []byte, all bool) int {
+			return copy(buf, strings.Repeat("x", payloadSize))
+		}
+		clipped := captureStacks(dump, 1024, 1024) // cap == initial: no retry possible
+		if len(clipped) != 1024 {
+			t.Errorf("len = %d, want the clipped %d", len(clipped), 1024)
+		}
+		// And with retry enabled the same dump comes back whole.
+		full := captureStacks(dump, 1024, 1<<20)
+		if len(full) != payloadSize {
+			t.Errorf("len = %d, want the full %d", len(full), payloadSize)
+		}
+	})
+}
+
+// captureAllStacks must return a complete dump for the live process.
+func TestCaptureAllStacksReturnsCompleteDump(t *testing.T) {
+	got := captureAllStacks()
+	if got == "" {
+		t.Fatal("expected a non-empty stack dump")
+	}
+	if !strings.HasPrefix(got, "goroutine ") {
+		t.Errorf("dump does not start with a goroutine header: %.60q", got)
+	}
+	// A complete dump ends with a full block, not mid-line.
+	if !strings.HasSuffix(got, "\n") {
+		t.Error("dump does not end on a line boundary, suggesting truncation")
+	}
+	// Every block must be parsable, which a clipped final block would not be.
+	blocks := SplitGoroutines(got)
+	for i, b := range blocks {
+		if _, _, _, ok := parseGoroutineHeader(b); !ok {
+			t.Errorf("block %d of %d is not parsable: %.80q", i, len(blocks), b)
+		}
+	}
+}
+
+func TestCallStackOfHandlesHeaderOnlyBlock(t *testing.T) {
+	if got := callStackOf("goroutine 1 [running]:"); got != "" {
+		t.Errorf("call stack for a header-only block = %q, want empty", got)
+	}
+	if got := callStackOf(""); got != "" {
+		t.Errorf("call stack for an empty block = %q, want empty", got)
+	}
+	got := callStackOf("goroutine 1 [running]:\nmain.main()\n\t/app/main.go:9 +0x1c\n")
+	if strings.Contains(got, "goroutine 1") {
+		t.Errorf("call stack still contains the header: %q", got)
+	}
+	if !strings.Contains(got, "main.main()") {
+		t.Errorf("call stack lost its body: %q", got)
+	}
+}

--- a/core/profile.go
+++ b/core/profile.go
@@ -6,6 +6,7 @@ import (
 	"runtime/pprof"
 	"strings"
 
+	"github.com/iyashjayesh/monigo/internal/logger"
 	"github.com/iyashjayesh/monigo/models"
 )
 
@@ -38,13 +39,48 @@ func WriteHeapProfile(filename string) error {
 	return pprof.WriteHeapProfile(f)
 }
 
+// maxStackBufferSize caps the buffer used to capture all goroutine stacks. An
+// application with tens of thousands of goroutines produces a very large dump;
+// beyond this we accept truncation rather than allocating without bound.
+const maxStackBufferSize = 64 << 20
+
+// initialStackBufferSize is the first buffer tried before any doubling.
+const initialStackBufferSize = 1 << 20
+
+// captureAllStacks returns the full stack trace for every goroutine.
+//
+// runtime.Stack truncates silently when the destination buffer is too small and
+// reports only how many bytes it wrote, so a single fixed-size call cannot tell
+// a complete dump from a clipped one. It is retried with a larger buffer while
+// the result exactly fills the buffer -- the only observable signal of
+// truncation -- which matters most for an application leaking goroutines, where
+// a clipped trace would undercount precisely when the data is needed.
+func captureAllStacks() string {
+	return captureStacks(runtime.Stack, initialStackBufferSize, maxStackBufferSize)
+}
+
+// captureStacks holds the retry logic, with the dump function injected so the
+// grow-and-retry path can be tested without needing a process that genuinely
+// has a multi-megabyte stack dump.
+func captureStacks(dump func(buf []byte, all bool) int, initialSize, maxSize int) string {
+	size := initialSize
+	for {
+		buf := make([]byte, size)
+		n := dump(buf, true)
+		if n < len(buf) {
+			return string(buf[:n])
+		}
+		if size >= maxSize {
+			logger.Log.Warn("goroutine stack dump truncated", "buffer_bytes", size)
+			return string(buf[:n])
+		}
+		size *= 2
+	}
+}
+
 // CollectGoRoutinesInfo returns the number of running Go routines and their stack traces split into separate goroutine blocks.
 func CollectGoRoutinesInfo() models.GoRoutinesStatistic {
-	// Creating a buffer to hold the stack trace
-	stackBuffer := make([]byte, 1<<20)
-	stackSize := runtime.Stack(stackBuffer, true)
-
-	stackTrace := string(stackBuffer[:stackSize]) // converting the stack trace to a single string
+	stackTrace := captureAllStacks()
 
 	goroutineBlocks := SplitGoroutines(stackTrace)           // splitting the stack trace into separate goroutine blocks
 	totalNumberOfRunningGoRoutines := runtime.NumGoroutine() // getting the total number of running goroutines
@@ -52,6 +88,7 @@ func CollectGoRoutinesInfo() models.GoRoutinesStatistic {
 	return models.GoRoutinesStatistic{
 		NumberOfGoroutines: totalNumberOfRunningGoRoutines,
 		StackView:          goroutineBlocks,
+		LeakReport:         leakReportFor(goroutineBlocks),
 	}
 }
 

--- a/models/apiModels.go
+++ b/models/apiModels.go
@@ -34,6 +34,10 @@ type ServiceStats struct {
 
 	// Health
 	Health ServiceHealth `json:"health"`
+
+	// GoroutineLeakReport is the verdict of the most recent leak-detection
+	// pass. Nil when no pass has run.
+	GoroutineLeakReport *GoroutineLeakReport `json:"goroutine_leak_report,omitempty"`
 }
 
 // CoreStatistics represents the core statistics of the service.
@@ -129,6 +133,51 @@ type Record struct {
 type GoRoutinesStatistic struct {
 	NumberOfGoroutines int      `json:"number_of_goroutines"`
 	StackView          []string `json:"stack_view"`
+	// LeakReport is nil when leak detection has not produced a verdict yet.
+	LeakReport *GoroutineLeakReport `json:"leak_report,omitempty"`
+}
+
+// GoroutineGroup describes a set of goroutines sharing an identical call stack.
+type GoroutineGroup struct {
+	// Signature identifies the shared call stack. It is a short hash, stable
+	// for as long as the call stack is byte-identical.
+	Signature string `json:"signature"`
+	// State is the runtime wait reason, e.g. "chan receive" or "select".
+	State string `json:"state"`
+	// Count is how many goroutines currently share this call stack.
+	Count int `json:"count"`
+	// BlockedMinutes is the longest time any goroutine in the group has been
+	// blocked, as reported by the runtime. Zero means under a minute, or a
+	// state the runtime does not timestamp.
+	BlockedMinutes int `json:"blocked_minutes"`
+	// Growth is the change in Count across the retained snapshot window.
+	Growth int `json:"growth"`
+	// Stale marks a group blocked at or beyond the configured threshold.
+	Stale bool `json:"stale"`
+	// Growing marks a group whose Count rose in every retained snapshot.
+	Growing bool `json:"growing"`
+	// CallStack is the shared stack, excluding the per-goroutine header line.
+	CallStack string `json:"call_stack"`
+}
+
+// GoroutineLeakReport is the verdict of a single leak-detection pass.
+type GoroutineLeakReport struct {
+	TotalGoroutines int `json:"total_goroutines"`
+	// StaleGoroutines counts goroutines blocked at or beyond the threshold.
+	StaleGoroutines int `json:"stale_goroutines"`
+	// GrowingGroups counts distinct call stacks growing monotonically.
+	GrowingGroups int `json:"growing_groups"`
+	// LeakSuspected is true when anything stale or growing was found.
+	LeakSuspected bool   `json:"leak_suspected"`
+	Message       string `json:"message"`
+	// StaleThresholdMinutes is the threshold this pass was evaluated against.
+	StaleThresholdMinutes int `json:"stale_threshold_minutes"`
+	// SnapshotsRetained is how many periodic snapshots growth was computed
+	// over. Growth is only reported once the window is full.
+	SnapshotsRetained int `json:"snapshots_retained"`
+	SnapshotsRequired int `json:"snapshots_required"`
+	// SuspiciousGroups holds the offending groups, worst first.
+	SuspiciousGroups []GoroutineGroup `json:"suspicious_groups,omitempty"`
 }
 
 // FunctionTraceDetails represents the function trace details.

--- a/monigo.go
+++ b/monigo.go
@@ -71,6 +71,9 @@ type Monigo struct {
 	SamplingRate            int       `json:"sampling_rate"`
 	StorageType             string    `json:"storage_type"`
 	AlertWebhookURL         string    `json:"alert_webhook_url,omitempty"`
+	// StaleGoroutineThreshold is how long a goroutine must stay blocked before
+	// leak detection reports it as stale. Zero means the 24h default.
+	StaleGoroutineThreshold time.Duration `json:"stale_goroutine_threshold,omitempty"`
 
 	// OpenTelemetry Configuration
 	OTelEndpoint string            `json:"otel_endpoint,omitempty"`
@@ -164,6 +167,8 @@ func (m *Monigo) initCommon() {
 	if m.AlertWebhookURL != "" {
 		alerting.SetWebhookURL(m.AlertWebhookURL)
 	}
+
+	core.SetStaleGoroutineThreshold(m.StaleGoroutineThreshold)
 
 	m.ServiceStartTime = time.Now().In(location)
 }

--- a/static/css/monigo-styles.css
+++ b/static/css/monigo-styles.css
@@ -536,3 +536,125 @@ body.dark-theme .iq-icon-box-2 {
 body.dark-theme .card:hover .iq-icon-box-2 {
     background-color: rgba(255, 92, 53, 0.18) !important;
 }
+
+/* --- Goroutine Leak Detection Panel --- */
+#goroutine-leak-panel {
+    margin-bottom: 20px;
+}
+
+.leak-status {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+    padding: 14px 18px;
+    border-radius: 10px;
+    font-size: 14px;
+    line-height: 1.5;
+    border: 1px solid transparent;
+}
+
+.leak-status i {
+    font-size: 16px;
+    flex-shrink: 0;
+}
+
+.leak-status-ok {
+    background: rgba(16, 185, 129, 0.08);
+    border-color: rgba(16, 185, 129, 0.25);
+    color: #047857;
+}
+
+.leak-status-warn {
+    background: rgba(249, 115, 22, 0.08);
+    border-color: rgba(249, 115, 22, 0.3);
+    color: #b45309;
+}
+
+.leak-meta {
+    font-size: 12px;
+    opacity: 0.75;
+    margin-left: auto;
+}
+
+.leak-groups {
+    margin-top: 12px;
+}
+
+.leak-group {
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    border-radius: 10px;
+    margin-bottom: 10px;
+    overflow: hidden;
+}
+
+.leak-group-head {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+    padding: 10px 14px;
+    background: rgba(148, 163, 184, 0.08);
+    font-size: 13px;
+}
+
+.leak-badge {
+    background: #f97316;
+    color: #fff;
+    border-radius: 20px;
+    padding: 2px 10px;
+    font-size: 12px;
+    font-weight: 700;
+    flex-shrink: 0;
+}
+
+.leak-group-head code {
+    background: transparent;
+    color: inherit;
+    font-weight: 600;
+    padding: 0;
+}
+
+.leak-reasons {
+    font-size: 12px;
+    opacity: 0.8;
+    margin-left: auto;
+}
+
+.leak-stack {
+    margin: 0;
+    padding: 12px 14px;
+    font-size: 12px;
+    line-height: 1.5;
+    max-height: 220px;
+    overflow: auto;
+    background: transparent;
+    border: 0;
+    white-space: pre;
+}
+
+/* Dark theme */
+body.dark-theme .leak-status-ok {
+    background: rgba(16, 185, 129, 0.12);
+    border-color: rgba(16, 185, 129, 0.35);
+    color: #6ee7b7;
+}
+
+body.dark-theme .leak-status-warn {
+    background: rgba(249, 115, 22, 0.12);
+    border-color: rgba(249, 115, 22, 0.4);
+    color: #fdba74;
+}
+
+body.dark-theme .leak-group {
+    border-color: rgba(148, 163, 184, 0.2);
+}
+
+body.dark-theme .leak-group-head {
+    background: rgba(148, 163, 184, 0.1);
+    color: #e5e7eb;
+}
+
+body.dark-theme .leak-stack {
+    color: #cbd5e1;
+}

--- a/static/go-routines-stats.html
+++ b/static/go-routines-stats.html
@@ -209,6 +209,7 @@
                     </div>
                         
                     <div class="col-lg-12">
+                        <div id="goroutine-leak-panel" style="display: none;"></div>
                         <div id="goroutines-container"></div>
                     </div>
                 </div>

--- a/static/js/goroutines.js
+++ b/static/js/goroutines.js
@@ -169,6 +169,81 @@ document.addEventListener('DOMContentLoaded', () => {
             });
     }
 
+    // Renders the goroutine leak verdict above the stack view. The panel is
+    // hidden entirely when nothing is suspected, so a healthy service shows no
+    // scary empty box.
+    function renderLeakReport(report) {
+        const panel = document.getElementById('goroutine-leak-panel');
+        if (!panel) {
+            return;
+        }
+        if (!report) {
+            panel.innerHTML = '';
+            panel.style.display = 'none';
+            return;
+        }
+
+        if (!report.leak_suspected) {
+            panel.style.display = 'block';
+            const warming = report.snapshots_retained < report.snapshots_required;
+            panel.innerHTML = `
+                <div class="leak-status leak-status-ok">
+                    <i class="fa fa-check-circle" aria-hidden="true"></i>
+                    <span><strong>No leak detected.</strong> ${escapeHtml(report.message)}</span>
+                    ${warming ? `<span class="leak-meta">growth tracking ${report.snapshots_retained}/${report.snapshots_required}</span>` : ''}
+                </div>`;
+            return;
+        }
+
+        const groups = (report.suspicious_groups || []).map(g => {
+            const reasons = [];
+            if (g.stale) {
+                reasons.push(`blocked ${formatMinutes(g.blocked_minutes)}`);
+            }
+            if (g.growing) {
+                reasons.push(`grew by ${g.growth} over ${report.snapshots_required} snapshots`);
+            }
+            return `
+                <div class="leak-group">
+                    <div class="leak-group-head">
+                        <span class="leak-badge">${g.count}&times;</span>
+                        <code>${escapeHtml(g.state)}</code>
+                        <span class="leak-reasons">${escapeHtml(reasons.join(' \u00b7 '))}</span>
+                    </div>
+                    <pre class="leak-stack">${escapeHtml(g.call_stack)}</pre>
+                </div>`;
+        }).join('');
+
+        panel.style.display = 'block';
+        panel.innerHTML = `
+            <div class="leak-status leak-status-warn">
+                <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+                <span><strong>Leak warning.</strong> ${escapeHtml(report.message)}</span>
+            </div>
+            <div class="leak-groups">${groups}</div>`;
+    }
+
+    function formatMinutes(minutes) {
+        if (minutes >= 1440) {
+            return `${Math.floor(minutes / 1440)}d`;
+        }
+        if (minutes >= 60) {
+            return `${Math.floor(minutes / 60)}h`;
+        }
+        return `${minutes}m`;
+    }
+
+    // Stack traces come from the monitored process, so they are escaped before
+    // ever touching innerHTML.
+    function escapeHtml(value) {
+        return String(value === undefined || value === null ? '' : value)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
     function fetchGoRoutines() {
         authenticatedFetch(`/monigo/api/v1/go-routines-stats`)
             .then(response => response.json())
@@ -207,6 +282,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
 
                 countElement.textContent = goroutines.length;
+                renderLeakReport(data.leak_report);
                 container.innerHTML = '';
 
                 // Group identical stack traces (ignoring the specific goroutine ID / state line)


### PR DESCRIPTION
Closes #44.

Goroutine leaks were the failure mode MoniGo was best placed to catch and didn't. It already dumped every goroutine stack on demand — it just rendered them as a list for a human to scroll. This turns that data into a verdict.

Two independent signals, both evaluated on every metrics collection cycle.

## Stale goroutines

The Go runtime already stamps a block duration into each goroutine's header once it has been parked for over a minute (`runtime/traceback.go:1259`):

```
goroutine 21 [chan receive, 47 minutes]:
```

So this needed **no new instrumentation** — only parsing of data MoniGo was already collecting and throwing away. Anything blocked at or beyond the threshold is reported. Default 24h, per the issue's suggestion; `WithStaleGoroutineThreshold` accepts any duration of 1m or more, and `Build()` rejects anything smaller because the runtime reports whole minutes and a finer threshold cannot be represented.

## Growing call stacks

Goroutines are grouped by identical call stack — the same grouping #50 added to the dashboard, now server-side — and per-group counts are retained across the last 5 cycles. A group is flagged only if its count rose in **every** retained cycle.

That rule is deliberately strict, because the expensive failure for a leak detector is crying wolf. Explicitly *not* flagged:

| Count sequence | Verdict | Why |
| --- | --- | --- |
| `3,3,3,3,3` | not a leak | steady state |
| `1,5,5,2,2` | not a leak | spike then settle |
| `1,2,1,2,3` | not a leak | sawtooth |
| `5,4,3,2,1` | not a leak | shrinking |
| `1,2,3,4,4` | not a leak | plateaued at the end |
| `1,2,3,4,5` | **leak** | rose at every step |

A stack absent from the oldest snapshot is treated as new rather than growing — otherwise every short-lived request handler gets flagged. And nothing is reported until the window is full, so a service that just started cannot raise an alarm off two data points; the report says `warming up (2/5 snapshots)` until then.

## Why detection lives in the collection path

`AnalyzeGoroutineLeaks` is called from `GetServiceStats`, not from the API handler. Growth is only meaningful across evenly spaced samples, and dashboard polling happens whenever somebody has a tab open. So the API path evaluates against the recorded history **without** appending to it, and a leak is caught whether or not anyone is watching. A suspected leak logs a warning and raises the alert webhook from #46 when configured.

## Prerequisite bug fixed

`CollectGoRoutinesInfo` used a fixed 1 MB buffer and a single `runtime.Stack` call:

```go
stackBuffer := make([]byte, 1<<20)
stackSize := runtime.Stack(stackBuffer, true)
```

`runtime.Stack` truncates silently and reports only bytes written, so the sole observable signal of truncation is a result that exactly fills the buffer. An application with thousands of goroutines got a clipped trace and undercounted — **precisely the case leak detection has to be right about**. It now grows and retries, capped at 64 MB, and the retry logic takes an injected dump function so the grow path is testable without needing a process that genuinely has a multi-megabyte dump.

## API

Additive and `omitempty`, on `GoRoutinesStatistic.LeakReport` and `ServiceStats.GoroutineLeakReport`:

```json
{
  "leak_report": {
    "total_goroutines": 456,
    "stale_goroutines": 443,
    "growing_groups": 1,
    "leak_suspected": true,
    "snapshots_retained": 5,
    "snapshots_required": 5,
    "stale_threshold_minutes": 1,
    "message": "Possible goroutine leak: 443 goroutine(s) blocked for at least 1m; 1 call stack(s) growing across the last 5 snapshots (total goroutines: 456).",
    "suspicious_groups": [
      { "signature": "a3f19c2d4e5b", "state": "chan receive", "count": 440,
        "blocked_minutes": 421, "growth": 100, "stale": true, "growing": true,
        "call_stack": "main.worker()\n\t/app/main.go:31 +0x24" }
    ]
  }
}
```

Payload is bounded: suspicious groups capped at 20, call stacks identified by a short hash rather than repeated, and only offending groups included — the full stack list is still `stack_view` as before.

## Dashboard

A warning panel above the stack view, hidden entirely when nothing is suspected so a healthy service shows no scary empty box. Each offending group shows its count, wait state, how long it has been blocked, how much it grew, and the shared stack. Stack text originates in the monitored process, so it is HTML-escaped before touching `innerHTML`. Styled for both themes.

## Verification

```
go vet ./...                      clean
go test ./... -race -count=1      all packages pass
core package coverage             88.1%
```

Beyond fixtures, this was tested against a deliberately leaking app — goroutines parked on a channel nobody sends to, 20 more every 4s:

- 456 goroutines, growing group correctly isolated to `main.main.func2.1()`, growth of 100 across the window
- `stale_goroutines: 0` initially (correct — none had crossed 1m), flipping to 443 once they had
- steady-state process not reported as leaking
- panel checked in both dashboard themes, no console errors

There is also an end-to-end Go test that leaks real goroutines in-process and asserts the detector catches them, releasing them on cleanup so it doesn't pollute the rest of the package.

## Deliberately out of scope

The issue's third bullet, **stack trace diffing in the dashboard**, is only partly covered: the server computes and reports growth per call stack, but there is no UI for comparing two arbitrary snapshots side by side. That is a bigger piece of dashboard work and worth its own issue — happy to file it.

Also unaddressed by design: a goroutine spinning in a loop has no `waitsince`, so the runtime never stamps a duration on it and stale detection cannot see it. Growth detection still catches it if the count rises.
