### PR TITLE
docs: add roadmap and PR-level development plan

### DIFF
--- a/DEVELOPMENT-PLAN.md
+++ b/DEVELOPMENT-PLAN.md
@@ -1,0 +1,363 @@
+# MoniGo Development Plan
+
+PR-level execution plan. Companion to [ROADMAP.md](ROADMAP.md), which carries the
+*why* and the evidence behind each item; this file carries the *what ships in
+which PR*.
+
+Last updated 2026-08-28.
+
+**Nothing here has been started.** Each PR below is specified to the point where it
+can be picked up without re-deriving the research.
+
+---
+
+## The guardrail problem, and why it comes first
+
+```
+Go tests:  142 across 11 packages
+CI runs:   go vet ./...  +  go test -race -cover ./...
+JS tests:  none
+CSS tests: none
+JS lint:   none
+```
+
+Every UI defect in ROADMAP.md Track 1 is the kind CI could have caught and
+didn't — a missing `main.js`, a CDN URL, 7.6 MB of unreferenced PNGs, a
+`timeRange`/`timeframe` typo. And every UI change made so far was verified by a
+human in a browser, which does not survive into CI.
+
+Tracks 2 and 3 are a **nine-step CSS/JS migration**. Doing that with no automated
+verification is the largest risk in this plan. So **B1 lands first** and adds
+guardrails that are pure Go, zero new dependencies, and run inside the existing CI
+job.
+
+---
+
+## Milestones
+
+| | Milestone | Closes | PRs |
+| --- | --- | --- | --- |
+| **A** | Release reachability | — | 1 |
+| **B** | Guardrails + correctness | part of #32 | 6 |
+| **C** | Design system | most of #32 | 9 |
+| **D** | Accessibility | rest of #32 | 2 |
+| **E** | Flame graphs | #43 | 2 |
+| — | Deferred | #42, new IA issue | — |
+
+Milestone letters are used rather than version numbers because Track 0 may
+renumber the release line. If option B in ROADMAP.md is taken, A ships as
+`v1.3.0`, B as `v1.4.0`, C as `v1.5.0`, D as `v1.6.0`.
+
+---
+
+## Milestone A — Release reachability
+
+Blocks nothing technically, but until it lands **no user can install any of this**.
+
+### A1 · Renumber the release line and document the release process
+
+- **Branch** `chore/release-line-v1`
+- **Files** `CHANGELOG.md`, `CONTRIBUTING.md`, `README.md`
+- **Scope**
+  - Renumber `[2.1.0]` → `[1.3.0]`, and annotate the `[2.0.0]` entry as never
+    published to the module proxy, with the reason.
+  - Add a "Releasing" section to `CONTRIBUTING.md`: tag, then **verify the proxy
+    actually serves it** with the `curl` shown in ROADMAP.md Track 0. This is the
+    step whose absence caused the problem.
+  - README install snippet confirmed to reference a version that resolves.
+- **Not in scope** Renaming the module to `/v2`. That is the alternative to this
+  PR, not a follow-up.
+- **Tests** None — docs only.
+- **Acceptance** After tagging `v1.3.0`, `curl
+  https://proxy.golang.org/github.com/iyashjayesh/monigo/@latest` returns
+  `v1.3.0`, and `go get github.com/iyashjayesh/monigo@latest` in a scratch module
+  pulls it.
+- **Effort** Small. **Risk** Low, but it is a public versioning decision — needs a
+  maintainer call before the PR, not during review.
+
+---
+
+## Milestone B — Guardrails and correctness
+
+Six PRs. B1 first; B2–B6 are independent of each other afterwards and can land in
+any order or in parallel.
+
+### B1 · Asset guardrails in CI
+
+- **Branch** `test/static-asset-guardrails`
+- **Files** new `static_assets_test.go`, `.github/workflows/test.yml`,
+  `static/index.html`, `static/function-metrics.html`
+- **Scope** Four checks, all pure Go against the existing `staticFiles embed.FS`:
+  1. **Every referenced asset exists.** Parse `src=` / `href=` out of each
+     embedded `.html`, resolve relative paths, `fs.Stat` each one. Fails today on
+     `js/core/main.js` — that failure is the point.
+  2. **No external URLs in embedded assets.** Reject `http://` and `https://` in
+     `src`/`href`/CSS `url()` across `static/`, with an explicit allowlist that
+     starts empty. Locks in the offline guarantee once B3 removes the CDN.
+  3. **Payload budget.** Sum the embedded tree; fail over a constant. Set to the
+     current size in this PR, tightened by B2. Stops 7.6 MB creeping back.
+  4. **JS parses.** A CI step running `node --check` over `static/js/*.js`
+     excluding the vendored `echarts.min.js` and `backend-bundle.min.js`. Node is
+     already on the GitHub runner; no `package.json`, no npm install.
+- **Also** Delete the `js/core/main.js` references so check 1 passes.
+- **Tests** The PR *is* tests. Include a deliberately-failing fixture in review
+  notes so a reviewer can confirm each check actually fires.
+- **Acceptance** `go test ./... -race` green; temporarily reintroducing a CDN URL,
+  a missing asset, or a syntax error each fails CI.
+- **Effort** Medium. **Risk** Low. **Value** Highest per line in this plan.
+
+### B2 · Remove unreferenced embedded assets
+
+- **Branch** `fix/drop-unreferenced-static-assets`
+- **Files** delete `static/assets/ss/d1–d10.png`, `static_assets_test.go` (budget)
+- **Scope** Delete 7.6 MB of PNGs referenced by nothing. Tighten B1's payload
+  budget to just above the new size. Check `.DS_Store` files under `static/` while
+  in here — they are also embedded.
+- **Tests** Budget assertion from B1 tightened.
+- **Acceptance** `du -sk static` drops from 16896 KB to ~9100 KB; dashboard renders
+  identically in all four pages.
+- **Note for the PR body** This does not shrink existing clones — the blobs remain
+  in git history — but the module zip is what `go get` downloads.
+- **Effort** Small. **Risk** Low.
+
+### B3 · Replace the icon layer with an inline SVG sprite
+
+- **Branch** `fix/inline-icon-sprite`
+- **Files** all four `static/*.html`, new `static/icons.html` partial or an inline
+  block, `static/css/monigo-styles.css`, `static/js/common.js`
+- **Scope**
+  - Eight `<symbol>` elements: `check-circle`, `chevron-right`, `download`,
+    `exclamation-triangle`, `github`, `refresh`, `moon`, `sun`. Sourced from a
+    permissive-licence set (Lucide is ISC — copying eight paths is fine; **adding
+    the library is not**), attribution in a CSS comment.
+  - Remove the Font Awesome `cdnjs` `<link>` from all four pages.
+  - Replace `fa-*` usages, and the dead `las la-bars` / `ri-menu-line` /
+    `ri-menu-3-line` hamburger icons — **this is what restores mobile navigation**.
+  - `common.js` theme toggle swaps `<use href>` rather than a font class.
+  - Decide `html2canvas`: vendor it (~200 KB, against the payload budget) or drop
+    the screenshot buttons. Recommendation: vendor it, because "Download Dashboard
+    Image" is a genuinely useful thing to paste into an incident channel.
+- **Tests** B1 checks 1 and 2 now pass with an empty allowlist.
+- **Acceptance** No network requests to any external host on any page (verify with
+  devtools offline mode); all eight icons render in both themes; sidebar opens
+  below 1300px and the navbar below 992px.
+- **Effort** Medium. **Risk** Medium — touches every page's markup. Screenshot
+  before/after each page in the PR.
+
+### B4 · Fix memory chart correctness
+
+- **Branch** `fix/memory-chart-raw-values`
+- **Files** `models/apiModels.go`, `core/core.go`, `api/api_test.go`,
+  `static/js/index.js`
+- **Scope**
+  - Expose the existing raw byte counts (`HeapAllocByServiceRaw`,
+    `HeapAllocBySystemRaw`, `TotalAllocByServiceRaw`, `TotalMemoryByOSRaw`) which
+    currently carry `json:"-"`. Add **new** JSON field names alongside the
+    formatted strings — additive, nothing existing breaks.
+  - Memory Distribution pie and Heap Memory Usage bar read raw bytes and format
+    only for display, instead of `parseFloat` on `"6.82 MB"`.
+  - Same treatment for the CPU/load `parseFloat` calls at `index.js:553-557`
+    if they suffer the same unit-stripping — confirm during implementation.
+  - CPU Statistics pie: stop plotting `total_cores` as a slice alongside the two
+    usage figures (it is the denominator, not a category).
+- **Tests** Go test asserting the raw fields are present and non-zero in the
+  `/metrics` response. A JS unit test is not possible without test
+  infrastructure — verify in-browser and attach numbers to the PR.
+- **Acceptance** A service using ~7 MB on a 16 GB host shows a visually
+  proportionate slice, not ~30%. Compare against `runtime.ReadMemStats` output
+  quoted in the PR body.
+- **Effort** Medium. **Risk** Low-medium — API surface grows; keep it additive.
+
+### B5 · Chart and range fixes
+
+- **Branch** `fix/chart-range-and-resize`
+- **Files** `static/js/reports.js`, `static/js/index.js`,
+  `static/js/historycharts.js`, `static/js/goroutines.js`
+- **Scope**
+  - `reports.js:100` `timeRange` → `timeframe` (ReferenceError on the 7d range).
+  - Pass `notMerge: true` to `setOption` so switching metric stops leaving stale
+    series behind.
+  - Add resize handling to the nine ECharts instances that lack it; one shared
+    helper rather than nine listeners.
+  - Default history window: make it longer than the sample interval, or derive it
+    from the configured interval, so a chart's first render is not empty.
+- **Tests** `node --check` from B1. Browser verification per fix in the PR body.
+- **Acceptance** 7d range returns data; switching metric replaces series; charts
+  reflow on window resize and rotation; first paint shows data.
+- **Effort** Small. **Risk** Low.
+
+### B6 · Interim contrast fix for the health number
+
+- **Branch** `fix/health-band-contrast`
+- **Files** `static/js/index.js`, `static/css/monigo-styles.css`
+- **Scope** Only if Milestone C slips. Replace the five band colours from the
+  vendored Grafana palette with values that clear 4.5:1 on white, and fix the
+  `--%` gauge placeholder (currently 2.54:1). Use the semantic tokens from
+  ROADMAP.md Track 2 so this is not thrown away by C.
+- **Tests** Contrast ratios computed and quoted in the PR body for all five bands.
+- **Acceptance** All five bands ≥ 4.5:1 in light theme; dark theme unchanged
+  (already passing).
+- **Effort** Small. **Risk** Low. **Skip if C1–C3 land within the same cycle.**
+
+---
+
+## Milestone C — Design system
+
+Nine PRs, in order. **The dashboard renders correctly after every one**, and each
+is independently revertable. C1–C5 are mechanical with zero-to-small visual diff;
+**C6–C9 change what the dashboard looks like and does, and want separate review.**
+
+Full token values, verified contrast ratios, and the chart palette are in
+ROADMAP.md Track 2 and the design research behind it.
+
+| PR | Branch | Scope | Visual diff | Effort |
+| --- | --- | --- | --- | --- |
+| **C1** | `feat/design-tokens` | Add `:root` + `body.dark-theme` token blocks at the top of `monigo-styles.css`. Change nothing else. | **None** | S |
+| **C2** | `refactor/tokenize-cards-tables` | Replace hex literals with tokens for cards and tables. Delete each `!important` the token now wins without. | None | M |
+| **C3** | `refactor/tokenize-chrome` | Same for sidebar, navbar, buttons, leak panel. | None | M |
+| **C4** | `refactor/collapse-dark-overrides` | Delete each `body.dark-theme` override as its light counterpart becomes tokenized. ~400 of ~440 lines go. | None | M |
+| **C5** | `refactor/borders-not-shadows` | Dark mode uses borders. Drop hover shadows and the `translateY(-2px)` card lift. | Small | S |
+| **C6** | `feat/type-and-density` | Six-size type scale; `tabular-nums` on every metric cell; 34px table rows with sticky header; code blocks fixed-size with `overflow-x: auto`, never wrapped. | **Yes** | M |
+| **C7** | `feat/charts-from-tokens` | ECharts theme reads tokens via `getComputedStyle`; toggle recolours without reload. | Small | M |
+| **C8** | `feat/single-health-encoding` | Retire the four competing health encodings, keep one. Replace the 300s `location.reload()` with in-place fetches. | **Yes** | L |
+| **C9** | `feat/loading-error-stale-states` | Accent bar after 300ms rather than a spinner over data; inline errors with the real message; one "as of" chip going amber past 2× and critical past 5× the poll interval; charts gap rather than flatline. | **Yes** | M |
+
+### Notes that change how these are reviewed
+
+- **C1 is the safest PR in this plan and the highest leverage.** Zero visual
+  diff — it only adds declarations. Merge it early even if C2 stalls.
+- **C4 is where the `!important` count should collapse.** Quote before/after counts
+  in the PR body: currently `203`. If it has not dropped substantially, the
+  tokenization in C2/C3 was incomplete.
+- **C8 deletes UI an existing user may be attached to** — the gauge, the health
+  banner, the coloured tag. Say so explicitly in the PR, with a screenshot of what
+  goes away, and consider a note in the changelog under Changed rather than Fixed.
+- **C8 also changes refresh behaviour.** In-place fetching means the page no longer
+  reloads; if anything depended on that reload (it shouldn't), it breaks. Test with
+  the service killed mid-session — the current behaviour navigates to the browser
+  error page, the new behaviour must show a stale-data state instead.
+- **C6 and C9 are the visible payoff.** If the project wants a "the dashboard looks
+  different now" moment for a release, it is these two.
+
+---
+
+## Milestone D — Accessibility
+
+Depends on C1 for the `--focus` token. 24 audit findings sit here, 8 must-fix.
+
+### D1 · Restore focus and keyboard operability
+
+- **Branch** `fix/focus-and-keyboard`
+- **Scope**
+  - Restore focus rings. `static/css/core/backend.css:11987` sets
+    `.btn:focus { outline: none; box-shadow: none }` and nothing in
+    `monigo-styles.css` replaces it — tab through the dashboard today and nothing
+    moves. Add `:focus-visible` styling driven by `--focus`.
+  - Make MoniGo's own controls real controls: the theme toggle (an `<a>` with no
+    `href`) becomes a `<button>` with `aria-pressed`; the refresh control (an
+    `aria-hidden` `<i>` with a click listener) becomes a labelled button; the
+    collapsible goroutine stack rows (click-only `div`s) become buttons with
+    `aria-expanded`.
+- **Acceptance** Every interactive element reachable and operable by keyboard with
+  a visible focus indicator in both themes.
+- **Effort** Medium. **Risk** Low.
+
+### D2 · Names, labels and announcements
+
+- **Branch** `fix/labels-and-live-regions`
+- **Scope** Label the four unlabelled `<select>` controls. Give the goroutine leak
+  verdict a live region so it is announced. Make the info "i" tooltips
+  keyboard-reachable and stop clipping their content with `white-space: nowrap`.
+  Fix the leak badge (white on `#f97316`, 2.80:1). Heading order and landmarks
+  across all four pages.
+- **Acceptance** A keyboard-and-screen-reader pass over each page, findings
+  recorded in the PR.
+- **Effort** Medium. **Risk** Low.
+
+---
+
+## Milestone E — Flame graphs (#43)
+
+Independent of B–D beyond B1. Two PRs, because the parsing change is valuable on
+its own.
+
+### E1 · Parse profiles in-process
+
+- **Branch** `feat/pprof-in-process`
+- **Scope** Replace `exec.Command("go", "tool", "pprof", ...)` with
+  `github.com/google/pprof` as a library. Removes the Go-SDK-on-host dependency
+  that `ViewFunctionMetrics` currently warns about, and removes the argument-
+  injection surface that #48 had to defend with input validation.
+- **Tests** Existing `ViewFunctionMetrics` tests should pass unchanged; add tests
+  over a committed fixture profile.
+- **Effort** Medium. **Risk** Medium — new dependency; check its transitive weight
+  against the payload/module-size concern before committing to it.
+
+### E2 · Render the flame graph
+
+- **Branch** `feat/flame-graph-view`
+- **Scope** Emit folded stacks as JSON from E1's parsed profile; render in the
+  Function Metrics page. **Do not CDN-load `d3-flame-graph`** — same offline
+  constraint as the icons, and B1 check 2 will fail. Hand-roll the renderer: a
+  flame graph is nested rectangles, a hover label, and click-to-zoom. Uses the
+  Track 2 chart palette and tokens.
+- **Effort** Large. **Risk** Medium.
+
+---
+
+## Deferred, with reasons
+
+### Information architecture → file as a new issue
+
+ROADMAP.md Track 4. The audit's position is that MoniGo is a catalogue of runtime
+metrics rather than an instrument for answering a question: no time correlation
+between signals, four unlinked range selectors, prime real estate spent on four
+constants. C8 and C9 treat symptoms. The shape question needs a design
+conversation before any code, and it should not sit inside #32 — **file it
+separately so #32 can close honestly** once B–D land.
+
+### External DB storage (#42) → blocked on a decision
+
+ROADMAP.md Track 6. The code is easy; the distribution question is not. Adding
+`pgx` + `mongo-driver` makes every consumer download drivers they will never use.
+Three options in the roadmap, including declining and documenting the `Storage`
+interface as the extension point. **Do not start coding.** Interacts with
+Milestone A, since separate modules need the versioning settled first.
+
+---
+
+## Dependency graph
+
+```
+A1 ─────────────────────────────────────────── independent, do first
+
+B1 ──┬── B2
+     ├── B3 ──────────── restores mobile nav
+     ├── B4
+     ├── B5
+     └── B6 (skip if C lands soon)
+
+C1 ──┬── C2 ── C3 ── C4 ── C5 ── C6 ── C7 ── C8 ── C9   (strictly ordered)
+     └────────────────────────────────── D1 ── D2       (D needs --focus from C1)
+
+B1 ── E1 ── E2                                          (independent of C and D)
+```
+
+Parallelisable: A1, the B2–B6 set, and E1 can all proceed at once after B1. The C
+chain is strictly sequential by design — each step assumes the previous one's
+tokens exist.
+
+## How to verify UI work until there is better tooling
+
+B1 gives CI syntax, asset and payload checks, but nothing that catches "this looks
+wrong". Until that exists, every UI PR should carry:
+
+- before/after screenshots of each affected page, **in both themes**;
+- computed contrast ratios for any colour pair introduced or changed, with the
+  numbers in the PR body rather than an assertion that it is fine;
+- a devtools-offline check for any PR touching assets;
+- for C5–C9, a check at 1280px, 992px and 375px widths, since the responsive
+  findings are unfixed until C6.
+
+The example app under `example/` with `WithStorageType("memory")` and a short
+`WithDataPointsSyncFrequency` is the fastest way to get a populated dashboard.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,427 @@
+# MoniGo Development Roadmap
+
+Living plan. Last updated 2026-08-28, after `v2.1.0` was cut in `CHANGELOG.md`.
+
+Everything below is either a verified measurement or an explicitly-labelled
+judgement call. Where a number appears, the command that produced it is given so
+it can be re-checked rather than trusted.
+
+---
+
+## Where things stand
+
+Merged and released as `2.1.0` in the changelog:
+
+| PR | What |
+| --- | --- |
+| #48 | Hardening: inverted health score, unbounded in-memory growth, `WithStorageType` no-op, threshold data race, storage/goroutine/fd leaks, constant-time credential comparison, pprof argument injection |
+| #49 | Opt-in health-breach webhook alerts (`WithAlertWebhook`) |
+| #50 | Dashboard dark mode, skeleton loading states, grouped goroutine stacks |
+| #51 | Goroutine leak detection (stale blocks + monotonically growing call stacks) |
+
+Open issues: **#32** (dashboard redesign), **#42** (external DB storage), **#43**
+(embedded flame graphs). #44 closed by #51; #45, #46, #47 closed.
+
+---
+
+## Track 0 — Release plumbing
+
+**This gates everything else and should be settled first.** None of the work
+above currently reaches anyone installing MoniGo.
+
+### The problem
+
+`v2.0.0` is tagged in git, but the Go module proxy refuses it:
+
+```
+$ curl -s https://proxy.golang.org/github.com/iyashjayesh/monigo/@latest
+{"Version":"v1.2.0","Time":"2026-01-23T05:37:43Z", ...}
+
+$ curl -s https://proxy.golang.org/github.com/iyashjayesh/monigo/@v/v2.0.0.info
+not found: invalid version: module contains a go.mod file, so module path must
+match major version ("github.com/iyashjayesh/monigo/v2")
+```
+
+`go.mod` declares `module github.com/iyashjayesh/monigo` with no `/v2` suffix, so
+`v2.x` tags are invalid for module consumers. **Everyone running `go get` today
+gets `v1.2.0` from January.** The OTel exporter, structured logging, graceful
+shutdown, and every fix in `2.1.0` are unreachable. Tagging `v2.1.0` would land in
+the same hole.
+
+### The decision
+
+| Option | Cost | Consequence |
+| --- | --- | --- |
+| **A. Rename module to `.../v2`** | Import-path change in every example, the README, and for anyone consuming v2 via a `replace` directive | Correct SemVer; `v2.x` tags become installable; the existing `v2.0.0` tag stays broken but is superseded |
+| **B. Renumber this release `v1.3.0`** | The `[2.0.0]` changelog entry becomes historically odd | Installable immediately, zero import churn; abandons the 2.x line as never-published |
+
+**Recommendation: B**, then A later if a genuinely breaking change ever justifies
+a major bump. B is one tag and a changelog note. A is a breaking change for users
+who are, per the proxy, currently zero — but it also forces `/v2` into every
+import path forever for a library whose API is not actually v2-shaped.
+
+Whichever is chosen, the follow-up is the same: **tag it, verify the proxy serves
+it**, and add a release step to `CONTRIBUTING.md` so this cannot silently recur.
+
+---
+
+## Track 1 — Correctness defects
+
+Six defects found during the UI audit. **These are bugs, not design**, and should
+land before any redesign work so the redesign is not built on top of them. One PR,
+or two if the memory fix needs API discussion.
+
+### 1.1 Memory charts display mathematically wrong values
+
+`static/js/index.js:688` and `:553-557` apply `parseFloat` to pre-formatted
+strings:
+
+```js
+value: parseFloat(data.memory_statistics.memory_used_by_service)   // "6.82 MB" -> 6.82
+value: parseFloat(data.memory_statistics.memory_used_by_system)    // "15.2 GB" -> 15.2
+```
+
+The unit is stripped, so 6.82 MB and 15.2 GB are plotted against each other in the
+same pie. The Heap chart mixes KB and MB under an axis labelled `MB`.
+
+A monitoring tool that misreports memory is worse than one that reports nothing,
+so this is the highest-priority item on the list.
+
+**Fix.** The raw byte counts already exist on `models.ServiceStats`
+(`HeapAllocByServiceRaw`, `HeapAllocBySystemRaw`, `TotalAllocByServiceRaw`,
+`TotalMemoryByOSRaw`) but carry `json:"-"`. Expose them — additively, under new
+JSON names so nothing existing breaks — and have the charts read raw bytes,
+formatting only for display. Add a Go test asserting the raw fields are present
+and non-zero in the API response.
+
+### 1.2 Mobile navigation is impossible, in every network condition
+
+Both hamburger controls reference icon fonts that are never loaded:
+
+```
+static/index.html:32    <i class="las la-bars wrapper-menu"></i>       Line Awesome
+static/index.html:126   <i class="ri-menu-line wrapper-menu"></i>      Remix Icon
+static/index.html:154   <i class="ri-menu-3-line"></i>                 Remix Icon
+```
+
+`font-family: remixicon` appears in the vendored CSS, but there is **no
+`@font-face` rule and no font file anywhere** under `static/` — no `.woff`,
+`.woff2` or `.ttf`. These render as zero-size empty elements always, not just
+offline. Below 1300px the sidebar cannot be opened; below 992px the navbar cannot
+either.
+
+**Fix.** Covered by 1.3 — replacing the icon layer restores navigation.
+
+### 1.3 Icons: remove the CDN dependency
+
+All four pages load Font Awesome 4.7.0 from `cdnjs.cloudflare.com`, and
+`index.html` also CDN-loads `html2canvas`. On an airgapped host — which is where a
+lot of production Go services live — every icon is a blank box.
+
+Total glyphs actually used: **eight.** `check-circle`, `chevron-right`,
+`download`, `exclamation-triangle`, `github`, `refresh`, `moon`, `sun`.
+
+**Fix.** An inline SVG `<symbol>` sprite in a shared partial, roughly 2 KB
+embedded. Replaces the CDN CSS, the never-loaded Line Awesome and Remix Icon
+references, and the missing font files in one change. Vendor `html2canvas` or drop
+the screenshot feature.
+
+### 1.4 A 404 on every dashboard load
+
+`static/index.html` and `static/function-metrics.html` both reference
+`./js/core/main.js`. `static/js/core/` contains only `app.js` and
+`backend-bundle.min.js`. Delete the reference.
+
+### 1.5 Reports "7d" throws a ReferenceError
+
+`static/js/reports.js:100` reads `timeRange` where every sibling branch reads
+`timeframe`. Selecting the 7-day range throws and blanks the table. One-word fix.
+
+### 1.6 Drop 7.6 MB of unreferenced assets
+
+```
+$ du -sk static           16896 KB   (16.5 MB)
+$ du -sk static/assets/ss  7772 KB   ( 7.6 MB)
+$ grep -rn "assets/ss" static/ README.md      # no matches
+```
+
+`//go:embed static/*` (`monigo.go:32`) compiles all of it into every user's binary
+and module download. `static/assets/ss/d1–d10.png` is referenced by no page, no
+JS, no CSS, and not the README. Delete.
+
+Note this does **not** shrink existing clones — the blobs stay in git history —
+but the module zip is what every `go get` downloads.
+
+### 1.7 Contrast: the health number, and one bug from #50
+
+Measured live via `getComputedStyle` on a running dashboard. The gauge percentage
+is coloured by band from the vendored Grafana palette:
+
+| Band | Token | Value | On white | |
+| --- | --- | --- | --- | --- |
+| ≥80 Excellent | `--green` | `#37872d` | 4.50 | pass |
+| ≥60 Good | `--lightgreen` | `#56a64b` | 3.02 | fail |
+| ≥50 Moderate | `--yellow` | `#eab839` | **1.84** | fail |
+| ≥40 Degraded | `--orange` | `#ef843c` | 2.61 | fail |
+| <40 Critical | `--red` | `#f2495c` | 3.57 | fail |
+
+Four of five states fail AA in light theme, and the two that matter during an
+incident are the worst — the dashboard becomes least legible exactly when
+something is wrong. `--green` also resolves to `#37872d` on `body` but `#78c091`
+on `:root`: two competing definitions inherited from the template.
+
+Separately, the gauge placeholder added in #50 (`--%` at `#9ca3af` on white) is
+**2.54:1** and fails. Both are fixed by the Track 2 token layer, but if Track 2
+slips, fix these two independently.
+
+---
+
+## Track 2 — Design system (issue #32)
+
+Full research, reference comparison and the verified token set sit behind this
+section; the PR-by-PR execution order is in
+[DEVELOPMENT-PLAN.md](DEVELOPMENT-PLAN.md) (milestone C). Summary and decisions
+below.
+
+### Direction
+
+**Primary reference: ClickHouse**, of twelve `DESIGN.md` systems evaluated. The
+only candidate shipping a real five-plane dark elevation ramp built from pure
+neutrals, so it inverts to light mode mechanically rather than requiring every hue
+to be re-picked. Its depth-from-hairlines-not-shadows doctrine, fixed-code-size
+rule, and one-big-number stat pattern are directly what MoniGo needs. Its yellow
+`#faff69` is rejected: yellow-as-brand beside amber-as-warning is the worst
+legibility failure available to an observability UI.
+
+Three governing doctrines:
+
+1. **One fact, one encoding.** Health is currently asserted four ways — a gauge, a
+   percentage, a coloured tag, and a top banner — which can disagree with each
+   other. Keep one.
+2. **Colour is never the only channel.** Every status carries a glyph, a word and a
+   colour; every chart series a direct label or dash pattern.
+3. **The accent is identity, never state.** `#ff5c35` never enters the chart
+   palette and never fills a data surface.
+
+### Issue #32's open decisions, resolved
+
+| Question | Answer | Why |
+| --- | --- | --- |
+| Bootstrap 5 vs Tailwind vs hybrid | **None of the three.** A token layer over existing Bootstrap 4 | Tailwind needs a build step; the UI is served from `embed.FS` with no npm, bundler or `package.json`. Bootstrap 5 is migration cost that fixes none of the real defects |
+| Lucide vs Heroicons vs FA6 | **None of the three.** Eight inline SVG symbols | Eight glyphs are in use. A sprite is ~2 KB; the smallest library is two orders of magnitude more, permanently, for every module consumer |
+| Dark mode priority | Shipped in #50; now the strongest argument for tokens | It cost 51 selectors and ~440 lines of overrides because there was no token layer to invert |
+| Mobile-first commitment | **No — desktop-dense first.** But mobile-*working* is non-negotiable | The user is an operator on a large monitor, deliberately. A centred 1280px column wastes half of it. Mobile-first optimises for the wrong primary case; today's mobile is nonetheless broken (1.2) |
+
+### The measured case for tokens
+
+```
+$ grep -oE '#[0-9a-fA-F]{3,8}' static/css/monigo-styles.css | wc -l    105
+$ grep -oE '#[0-9a-fA-F]{3,8}' static/css/monigo-styles.css | sort -u | wc -l    22
+$ grep -c '!important' static/css/monigo-styles.css                    203
+$ grep -c 'body\.dark-theme' static/css/monigo-styles.css               51
+```
+
+Eight values account for 82 of the 105 literals (`#1f2937`×21, `#ff5c35`×17,
+`#f3f4f6`×12, `#374151`×9, `#e5e7eb`×7, `#9ca3af`×7, `#ffffff`×6, `#111827`×6),
+and every one is a 1:1 token substitution. **203 `!important` declarations is the
+real disease** — they exist because there was no cascade layer to win with. Around
+400 of the ~440 dark-override lines collapse (~91%), leaving a small block of
+genuine structural exceptions.
+
+Also worth knowing: `monigo-styles.css` already reaches for `'Inter'` (line 338)
+and `'Fira Code'` (line 318). Neither ships, so it silently falls back today while
+encoding the wrong font metrics.
+
+### Migration order
+
+The dashboard renders correctly after every step, and each is independently
+revertable. Steps 2–5 are mechanical; **6–9 change appearance and behaviour and
+deserve separate review.**
+
+1. Track 1 defects first (above) — bugs before design.
+2. Add the `:root` + `body.dark-theme` token blocks. Change nothing else. Zero
+   visual diff, reviewable and revertable on its own.
+3. Tokenize light theme one section at a time: cards → tables → sidebar/navbar →
+   buttons → leak panel. Delete each `!important` where the token now wins unaided.
+4. Delete each dark override as its light counterpart lands. This is where the
+   ~400 lines go. Same order, so mistakes stay scoped to one component.
+5. Shadows out, borders in. Drop hover shadows and the `translateY(-2px)` card
+   lift, so a 20-tile grid stops bouncing under the cursor.
+6. Type and density: six sizes, `tabular-nums` on every metric cell so live
+   columns stop jittering on each poll, 34px table rows with a sticky header, code
+   blocks at fixed size with `overflow-x: auto` and never wrapped.
+7. Charts read from tokens via `getComputedStyle`, so the theme toggle recolours
+   without a reload. Fix the nine ECharts instances that never resize, and pass
+   `notMerge` so switching metric stops leaving stale series behind.
+8. Retire redundant encodings. Keep one health representation: value, sparkline,
+   threshold-coloured text. Replace the 300s `location.reload()` with in-place
+   fetches so investigation state survives. **This step deletes UI an existing
+   user may be attached to — flag it in the PR.**
+9. Loading, error and stale states, built from the tokens that now exist: a 2px
+   accent bar on the card chrome after a 300ms delay rather than a spinner over
+   the data; errors inline with the real message; one "as of" chip that goes amber
+   past 2× the poll interval and critical past 5×. Charts gap at the last real
+   sample rather than flatlining. A stale value never keeps a green tag.
+
+### Constraints that must not be violated
+
+- **No webfont, including "just Inter" and "just the mono".** Every byte ships in
+  every consumer's binary, and CDN fonts do not resolve on airgapped hosts.
+  Corollary: cap negative letter-spacing at −0.6px and only above 24px, and cap
+  weight at 600 — heavier weights synthesise unpredictably on Linux browsers.
+- **No icon library after removing Font Awesome.** Hand-write the ninth glyph.
+- **No marketing rhythm.** Spacing scale stops at 32px, type scale at 30px, no
+  centred max-width container.
+- **No build pipeline for the tokens.** If an improvement needs a `package.json`,
+  it is not an improvement here.
+
+---
+
+## Track 3 — Accessibility pass (issue #32, remainder)
+
+24 findings sit in this dimension, 8 of them must-fix. Distinct enough from the
+token work to be its own PR, and it depends on Track 2 for the `--focus` token.
+
+- Every interaction MoniGo itself added is mouse-only: the theme toggle (an `<a>`
+  with no `href`), the manual refresh control (an `aria-hidden` `<i>` with a click
+  listener), the collapsible goroutine stack rows (click-only `div`s), the info
+  "i" tooltips (hover-only, keyboard-unreachable, content clipped by
+  `white-space: nowrap`).
+- `.btn:focus { outline: none; box-shadow: none }` in the vendored
+  `static/css/core/backend.css` strips the focus ring from every button, and
+  nothing in `monigo-styles.css` restores it. Tab through the dashboard today and
+  nothing moves visually.
+- Four functional `<select>` controls have no label.
+- The goroutine leak verdict is injected with no live region, so it is never
+  announced.
+- Leak badge (white on `#f97316`) is 2.80:1 — the count an operator most needs to
+  read.
+
+---
+
+## Track 4 — Information architecture
+
+The open question, and the one with no obvious answer. Recorded rather than
+scheduled.
+
+The audit's position: MoniGo is currently organised as *a catalogue of every
+metric the Go runtime exposes*, not as an instrument for answering a question. All
+three incident scenarios end with the operator scrolling a 17-widget page whose
+four history charts each carry their own unlinked time dropdown. Concretely:
+
+- No time correlation between signals — each chart is an isolated widget with its
+  own range selector, so "did the goroutine count spike when memory did" cannot be
+  answered.
+- Default history window (5m) is shorter than the default sample interval (5m), so
+  every chart's first render is empty.
+- The top-right eight columns of prime real estate hold four constants (service
+  name, Go version, start time, PID) that can never be the reason anyone opened
+  the page.
+- Failure states: every fetch site swallows errors to `console.error`, nothing
+  says how old the data is, and the 5-minute reload wipes state exactly when the
+  service dies.
+
+Worth its own issue and a design conversation before any code. Steps 8 and 9 of
+Track 2 address the symptoms; this is the shape question.
+
+---
+
+## Track 5 — Embedded flame graphs (issue #43)
+
+Self-contained, high visual payoff, no architectural risk. Good candidate once
+Tracks 1–2 land.
+
+Currently `ViewFunctionMetrics` shells out to `go tool pprof`, which means profile
+views already fail when the Go SDK is absent from the host — a limitation the code
+acknowledges in its own warning message.
+
+Approach: parse profiles in-process with `github.com/google/pprof` rather than
+shelling out (this also removes the Go-SDK dependency), emit folded stacks as
+JSON, and render with a vendored flame-graph renderer. **Do not CDN-load
+`d3-flame-graph`** — same offline constraint as the icons. Either vendor it or
+hand-roll the renderer; a flame graph is rectangles and a hover label, and the
+hand-rolled version avoids adding d3 to the embedded payload.
+
+---
+
+## Track 6 — External database storage (issue #42)
+
+**Blocked on a design decision, not on effort.** Do not start coding this.
+
+The `Storage` interface is already decoupled and tiny:
+
+```go
+type Storage interface {
+    InsertRows(rows []Row) error
+    Select(metric string, labels []Label, start, end int64) ([]DataPoint, error)
+    Close() error
+}
+```
+
+So implementing Postgres and MongoDB is straightforward plumbing. The problem is
+distribution: MoniGo is a library embedded in other people's binaries, `go.mod`
+already carries 44 requires including all of Fiber, and adding `pgx` +
+`mongo-driver` makes every user pay for drivers they will never use.
+
+Options to settle first:
+
+- **Separate modules** — `monigo-storage-postgres`, `monigo-storage-mongo`, each
+  with its own `go.mod`. Cleanest; users opt in by importing. Interacts with
+  Track 0, so settle module versioning first.
+- **Build tags** — keeps one module, but the drivers still appear in `go.mod` and
+  still get downloaded.
+- **Decline** — document the `Storage` interface as the extension point and let
+  users implement their own. Zero cost, and arguably the right answer for a
+  library whose selling point is that it is a drop-in.
+
+Secondary design issue: `Select(metric, labels, start, end)` maps cleanly onto
+neither SQL nor documents, and multi-instance deployments writing to one database
+raise a labelling question (`host` is currently a single label) that the interface
+does not currently express.
+
+---
+
+## Sequencing
+
+PR-level breakdown, branch names, per-PR tests and acceptance criteria are in
+[DEVELOPMENT-PLAN.md](DEVELOPMENT-PLAN.md). This section is the track-level view.
+
+```
+Track 0  release plumbing        ── settle first, one tag + a doc note
+   │
+Track 1  correctness defects     ── one PR, bugs before design
+   │
+Track 2  tokens, steps 2-5       ── mechanical, zero-to-small visual diff
+   │        │
+   │        └── steps 6-9        ── visible change, separate review each
+   │
+Track 3  accessibility           ── after Track 2 (needs --focus token)
+   │
+Track 5  flame graphs (#43)      ── independent, any time after Track 1
+   │
+Track 4  IA rework               ── needs a design conversation first
+Track 6  external storage (#42)  ── blocked on the module decision
+```
+
+Tracks 1, 2 and 3 close the bulk of #32. Track 4 is what remains of it afterwards
+and should probably become its own issue so #32 can close honestly.
+
+## Notes on method
+
+The audit behind Tracks 1–4 ran 12 agents across 6 dimensions, each dimension
+paired with an agent instructed to refute rather than confirm: 107 raw findings,
+104 retained. A second workflow of 6 agents evaluated 12 design references and
+researched Grafana, Datadog, Sentry and pprof conventions.
+
+Two agent findings were **wrong** and were withdrawn after local checking, both
+originally ranked must-fix:
+
+- *"The gauge arc never renders because `var()` is used in an SVG presentation
+  attribute."* Probed live: `arc_computed_stroke` returns `rgb(55, 135, 45)`.
+  Chrome resolves it. The arc renders and tracks the band.
+- *"`.gauge` is already neutralised with `display:none`."* It is
+  `display: block !important`; only `.gauge::after` is hidden.
+
+All 22 contrast ratios and 16 chart-series values in the proposed token set were
+independently recomputed and matched exactly. Treat any unverified agent claim in
+future work the same way.


### PR DESCRIPTION
Two companion planning documents, produced from the audit and design research behind #32.

**[ROADMAP.md](https://github.com/iyashjayesh/monigo/blob/docs/roadmap-and-development-plan/ROADMAP.md)** — seven tracks with the evidence, the decisions that gate them, and sequencing.
**[DEVELOPMENT-PLAN.md](https://github.com/iyashjayesh/monigo/blob/docs/roadmap-and-development-plan/DEVELOPMENT-PLAN.md)** — 20 PRs across five milestones, each with branch, scope, tests, acceptance criteria, effort and risk.

## Two findings that reorder the priorities

**Nothing released since January is installable.**

```
$ curl -s https://proxy.golang.org/github.com/iyashjayesh/monigo/@latest
{"Version":"v1.2.0","Time":"2026-01-23T05:37:43Z", ...}
```

`v2.0.0` is tagged, but the proxy rejects it — `go.mod` has no `/v2` suffix, so `v2.x` tags are invalid for module consumers. Every fix in #48, #49, #50 and #51 is unreachable to anyone running `go get`. Track 0 gives two options and recommends renumbering to `v1.3.0` over renaming the module.

**There is no automated verification of the UI.** 142 Go tests; zero JS or CSS checks. Every defect the audit found is one CI could have caught. Milestone C is a nine-step CSS/JS migration, so the first code PR (B1) adds asset guardrails in pure Go against the existing `embed.FS` — every-referenced-asset-exists, no-external-URLs, payload budget, and `node --check` — before any redesign work starts.

## Method

12 agents across 6 audit dimensions, each paired with an agent instructed to refute rather than confirm (107 raw findings, 104 retained). A second workflow of 6 agents evaluated 12 design references and researched Grafana, Datadog, Sentry and pprof conventions.

Every number in both documents was re-derived locally, and the commands are quoted inline. Two agent findings were **wrong** and are recorded as withdrawn — both originally ranked must-fix. All 22 contrast ratios and 16 chart-series values in the proposed token set were independently recomputed and matched exactly.

## Scope

Docs only — no code changes, so CI has nothing to exercise here beyond the existing suite. The plan deliberately does **not** close #32; see the scope note in ROADMAP.md and the follow-up issue for the information-architecture question.