### PR TITLE
fix: plot memory charts from raw byte counts instead of display strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Memory Distribution pie plotted values of different magnitudes against each other.** The chart parsed a number out of the pre-formatted display strings (`"2.68 MB"`, `"12.93 GB"`), which discards the unit -- so a service using 2.68 MB rendered as 14.3% of the pie instead of 0.02%, a ~700x overstatement of its footprint
+- **Heap Memory Usage chart mixed units under an "MB" axis.** It read `mem_stats_records[].record_value`, a display number whose unit lives in a separate `record_unit` field that the chart ignored. Once heap use crosses 1 GB, `HeapSys` reports in GB while `HeapAlloc` is still in MB, and the taller bar renders shorter. It now reads `raw_mem_stats_records`, which is in one consistent unit
+- **CPU Statistics pie plotted `total_cores` as a slice alongside its own components**, so the chart always summed to twice the real core count. The third slice is now idle cores
+
+### Added
+- Unformatted memory values on the metrics API: `total_system_memory_bytes`, `memory_used_by_system_bytes`, `memory_used_by_service_bytes`, `available_memory_bytes`, `stack_memory_usage_bytes`, `gc_pause_duration_ms`. Additive -- the existing formatted string fields are unchanged. Anything doing arithmetic on or plotting these metrics must use the raw fields, since the strings carry a unit suffix
+
 ## [2.1.0] - 2026-08-28
 
 ### Security

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -190,3 +190,120 @@ func TestGetReportData_InvalidBody(t *testing.T) {
 		t.Errorf("expected 400, got %d", w.Code)
 	}
 }
+
+// The dashboard charts must plot unformatted byte counts, not the display
+// strings. The string fields carry a unit suffix ("6.82 MB", "15.2 GB"), so
+// parsing a number out of one drops the unit and puts values of different
+// magnitudes on the same axis -- which is how the Memory Distribution pie came
+// to render a service using megabytes as a comparable slice to a system using
+// gigabytes.
+func TestServiceMetricsExposesRawMemoryBytes(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/monigo/api/v1/metrics", nil)
+	w := httptest.NewRecorder()
+	GetServiceStatistics(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var payload map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&payload); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	memStats, ok := payload["memory_statistics"].(map[string]interface{})
+	if !ok {
+		t.Fatal("response has no memory_statistics object")
+	}
+
+	// Fields the charts depend on. Absence means a chart silently falls back to
+	// zero or to a formatted string.
+	required := []string{
+		"total_system_memory_bytes",
+		"memory_used_by_system_bytes",
+		"memory_used_by_service_bytes",
+		"available_memory_bytes",
+		"stack_memory_usage_bytes",
+		"gc_pause_duration_ms",
+	}
+	for _, field := range required {
+		v, present := memStats[field]
+		if !present {
+			t.Errorf("memory_statistics.%s is missing; charts cannot plot without it", field)
+			continue
+		}
+		if _, isNumber := v.(float64); !isNumber {
+			t.Errorf("memory_statistics.%s = %T, want a number (a string would carry a unit suffix)", field, v)
+		}
+	}
+
+	// Total system memory is the one value that is always non-zero on a working
+	// host, so it is the sanity check that these are real readings.
+	if total, _ := memStats["total_system_memory_bytes"].(float64); total <= 0 {
+		t.Errorf("total_system_memory_bytes = %v, want > 0", total)
+	}
+
+	// Byte counts must be plottable against each other: the service cannot use
+	// more than the system total.
+	svc, _ := memStats["memory_used_by_service_bytes"].(float64)
+	total, _ := memStats["total_system_memory_bytes"].(float64)
+	if total > 0 && svc > total {
+		t.Errorf("memory_used_by_service_bytes (%v) exceeds total_system_memory_bytes (%v); "+
+			"these are not in the same unit", svc, total)
+	}
+}
+
+// raw_mem_stats_records is what the Heap Memory Usage chart reads. Unlike
+// mem_stats_records -- whose record_value is a display number with its unit in a
+// separate record_unit field -- every entry here is in one consistent unit.
+func TestServiceMetricsExposesRawHeapRecords(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/monigo/api/v1/metrics", nil)
+	w := httptest.NewRecorder()
+	GetServiceStatistics(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var payload map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&payload); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	memStats, _ := payload["memory_statistics"].(map[string]interface{})
+	records, ok := memStats["raw_mem_stats_records"].([]interface{})
+	if !ok {
+		t.Fatal("memory_statistics.raw_mem_stats_records is missing or not an array")
+	}
+
+	byName := map[string]float64{}
+	for _, r := range records {
+		rec, ok := r.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		name, _ := rec["record_name"].(string)
+		value, isNumber := rec["record_value"].(float64)
+		if !isNumber {
+			t.Errorf("raw_mem_stats_records[%q].record_value = %T, want a number", name, rec["record_value"])
+			continue
+		}
+		byName[name] = value
+	}
+
+	// The five series the heap chart plots.
+	for _, key := range []string{"heap_alloc", "heap_sys", "heap_idle", "heap_inuse", "heap_released"} {
+		if _, present := byName[key]; !present {
+			t.Errorf("raw_mem_stats_records is missing %q, which the heap chart plots", key)
+		}
+	}
+
+	// heap_sys is everything the heap obtained from the OS, so it cannot be
+	// smaller than the part currently allocated. If it is, the two are not in
+	// the same unit -- exactly the bug this replaced.
+	if alloc, okA := byName["heap_alloc"]; okA {
+		if sys, okS := byName["heap_sys"]; okS && sys > 0 && alloc > sys {
+			t.Errorf("heap_alloc (%v) exceeds heap_sys (%v); these are not in the same unit", alloc, sys)
+		}
+	}
+}

--- a/models/apiModels.go
+++ b/models/apiModels.go
@@ -92,13 +92,18 @@ type MemoryStatistics struct {
 	FreeSwapMemory      string               `json:"free_swap_memory"`
 	MemStatsRecords     []Record             `json:"mem_stats_records"`     // List of memory statistic records.
 	RawMemStatsRecords  []RawMemStatsRecords `json:"raw_mem_stats_records"` // RawMemStatsRecords holds a list of raw memory statistic records.
-	// Raw values for storage
-	TotalSystemMemoryRaw   float64 `json:"-"`
-	MemoryUsedBySystemRaw  float64 `json:"-"`
-	MemoryUsedByServiceRaw float64 `json:"-"`
-	AvailableMemoryRaw     float64 `json:"-"`
-	GCPauseDurationRaw     float64 `json:"-"`
-	StackMemoryUsageRaw    float64 `json:"-"`
+
+	// Unformatted values, in bytes unless noted. The string fields above are
+	// pre-formatted for display and carry a unit suffix ("6.82 MB", "15.2 GB"),
+	// which makes them unsafe to compare or plot: parsing a number out of one
+	// discards the unit, so a value in MB and a value in GB end up on the same
+	// axis. Anything doing arithmetic or drawing a chart must use these instead.
+	TotalSystemMemoryRaw   float64 `json:"total_system_memory_bytes"`
+	MemoryUsedBySystemRaw  float64 `json:"memory_used_by_system_bytes"`
+	MemoryUsedByServiceRaw float64 `json:"memory_used_by_service_bytes"`
+	AvailableMemoryRaw     float64 `json:"available_memory_bytes"`
+	StackMemoryUsageRaw    float64 `json:"stack_memory_usage_bytes"`
+	GCPauseDurationRaw     float64 `json:"gc_pause_duration_ms"`
 }
 
 // ServiceHealth represents the health of the service.

--- a/static/index.html
+++ b/static/index.html
@@ -502,7 +502,7 @@
                                     <h4 class="card-title">
                                         CPU Statistics
                                         <span class="info-icon"
-                                            data-tooltip="CPU Statistics shows the 'Cores Used by Service', 'Cores Used by System', 'Total Cores'">i</span>
+                                            data-tooltip="CPU Statistics shows the 'Cores Used by Service', 'Cores Used by System', 'Idle Cores'">i</span>
                                     </h4>
                                 </div>
                                 <button id="download-cpu-statistics-btn" type="button" class="btn btn-primary add-list">
@@ -636,7 +636,7 @@
                                     <h4 class="card-title">
                                         CPU Usage
                                         <span class="info-icon"
-                                            data-tooltip="CPU Usage shows the 'Total Cores', 'Cores Used by Service', 'Cores Used by System'">i</span>
+                                            data-tooltip="CPU Usage shows the 'Cores Used by Service', 'Cores Used by System', 'Idle Cores'">i</span>
                                     </h4>
                                 </div>
                                 <button id="download-cpu-usage-btn" type="button" class="btn btn-primary add-list">

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -477,6 +477,31 @@ document.addEventListener('DOMContentLoaded', () => {
     //   })
     // }
 
+    // Formats a byte count for display. Chart *values* are always fed in one
+    // consistent unit; only the label passes through here, so nothing downstream
+    // compares numbers that were formatted at different scales.
+    function formatBytes(bytes) {
+        if (!isFinite(bytes) || bytes < 0) {
+            return '-';
+        }
+        const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+        let value = bytes;
+        let i = 0;
+        while (value >= 1024 && i < units.length - 1) {
+            value /= 1024;
+            i++;
+        }
+        return `${value.toFixed(2)} ${units[i]}`;
+    }
+
+    // Reads a raw memory statistic in bytes. The sibling string fields are
+    // pre-formatted with a unit suffix, so parsing a number out of them silently
+    // drops the unit and puts MB and GB on the same axis.
+    function memBytes(memoryStatistics, key) {
+        const value = memoryStatistics ? memoryStatistics[key] : undefined;
+        return typeof value === 'number' && isFinite(value) ? value : 0;
+    }
+
     // KB
     function renderCharts(data) {
         const isDark = document.body.classList.contains('dark-theme');
@@ -609,7 +634,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         }
                     },
                     {
-                        name: 'Total Cores',
+                        name: 'Idle Cores',
                         icon: 'rect',
                         itemStyle: {
                             color: '#FFD166'
@@ -636,8 +661,17 @@ document.addEventListener('DOMContentLoaded', () => {
                             itemStyle: { color: '#FF6F61' }
                         },
                         {
-                            value: cpu_statistics.total_cores,
-                            name: 'Total Cores',
+                            // Total cores minus what is in use. Plotting
+                            // total_cores itself made the denominator a slice of
+                            // its own pie, so the chart always summed to twice
+                            // the real core count.
+                            value: Math.max(
+                                0,
+                                (cpu_statistics.total_cores || 0) -
+                                    (cpu_statistics.cores_used_by_service || 0) -
+                                    (cpu_statistics.cores_used_by_system || 0)
+                            ),
+                            name: 'Idle Cores',
                             itemStyle: { color: '#FFD166' }
                         }
                     ],
@@ -662,7 +696,7 @@ document.addEventListener('DOMContentLoaded', () => {
             tooltip: {
                 trigger: 'item',
                 formatter: function (params) {
-                    return `${params.seriesName}<br/>${params.name}: ${params.value} (${params.percent}%)`;
+                    return `${params.seriesName}<br/>${params.name}: ${formatBytes(params.value)} (${params.percent}%)`;
                 }
             },
             legend: {
@@ -685,21 +719,15 @@ document.addEventListener('DOMContentLoaded', () => {
                     label: { color: textColor },
                     data: [
                         {
-                            value: parseFloat(
-                                data.memory_statistics.memory_used_by_service
-                            ),
+                            value: memBytes(data.memory_statistics, 'memory_used_by_service_bytes'),
                             name: 'Memory Used by Service'
                         },
                         {
-                            value: parseFloat(
-                                data.memory_statistics.memory_used_by_system
-                            ),
+                            value: memBytes(data.memory_statistics, 'memory_used_by_system_bytes'),
                             name: 'Memory Used by System'
                         },
                         {
-                            value: parseFloat(
-                                data.memory_statistics.available_memory
-                            ),
+                            value: memBytes(data.memory_statistics, 'available_memory_bytes'),
                             name: 'Available Memory'
                         }
                     ],
@@ -714,23 +742,26 @@ document.addEventListener('DOMContentLoaded', () => {
             ]
         });
 
-        let values = [];
-        data.memory_statistics.mem_stats_records.forEach((record) => {
-            if (record.record_name === 'HeapAlloc') {
-                values.push(record.record_value);
-            } else if (record.record_name === 'HeapSys') {
-                values.push(record.record_value);
-            } else if (record.record_name === 'HeapIdle') {
-                values.push(record.record_value);
-            } else if (record.record_name === 'HeapInuse') {
-                values.push(record.record_value);
-            } else if (record.record_name === 'HeapReleased') {
-                values.push(record.record_value);
-            }
+        // mem_stats_records carries a DISPLAY value with its unit in a separate
+        // record_unit field -- HeapAlloc might be 6.82 "MB" while HeapSys is 1.20
+        // "GB". Reading record_value and ignoring record_unit put both on one "MB"
+        // axis, so HeapSys rendered five times shorter than HeapAlloc while
+        // actually being ~180 times larger.
+        //
+        // raw_mem_stats_records carries the same metrics in a single consistent
+        // unit (base-1024 KB), which is what a chart needs.
+        const rawMemStats = {};
+        (data.memory_statistics.raw_mem_stats_records || []).forEach((record) => {
+            rawMemStats[record.record_name] = record.record_value;
+        });
 
-            if (values.length === 5) {
-                return;
-            }
+        const KB_PER_MB = 1024;
+        const heapKeys = ['heap_alloc', 'heap_sys', 'heap_idle', 'heap_inuse', 'heap_released'];
+        const values = heapKeys.map((key) => {
+            const kb = rawMemStats[key];
+            return typeof kb === 'number' && isFinite(kb)
+                ? Number((kb / KB_PER_MB).toFixed(3))
+                : 0;
         });
 
         // Heap Usage Chart
@@ -740,7 +771,15 @@ document.addEventListener('DOMContentLoaded', () => {
                 text: 'Heap Memory Usage',
                 textStyle: { color: titleColor }
             },
-            tooltip: {},
+            tooltip: {
+                trigger: 'axis',
+                formatter: function (params) {
+                    if (!params || !params.length) {
+                        return '';
+                    }
+                    return `${params[0].name}: ${params[0].value} MB`;
+                }
+            },
             xAxis: {
                 type: 'category',
                 data: [


### PR DESCRIPTION
Milestone **B4** from [DEVELOPMENT-PLAN.md](https://github.com/iyashjayesh/monigo/blob/main/DEVELOPMENT-PLAN.md). Refs #32.

The dashboard's memory charts reported wrong numbers. That is the worst failure available to a monitoring tool — the reading looks authoritative and isn't.

## Memory Distribution pie: a ~700× overstatement

`parseFloat` was applied to pre-formatted display strings, which strips the unit:

```js
value: parseFloat(data.memory_statistics.memory_used_by_service)  // "2.68 MB"  -> 2.68
value: parseFloat(data.memory_statistics.memory_used_by_system)   // "12.93 GB" -> 12.93
```

Measured against a live service, before and after:

| Slice | Formatted string | **Old** (units stripped) | **New** (raw bytes) |
| --- | --- | --- | --- |
| Memory Used by Service | `2.68 MB` | **14.3%** | **0.02%** |
| Memory Used by System | `12.93 GB` | 69.2% | 80.82% |
| Available Memory | `3.07 GB` | 16.4% | 19.17% |

A process using 2.68 MB rendered as nearly a seventh of system memory — in the one chart an operator would consult to decide whether the service is the problem.

## Heap Memory Usage: subtler, and currently latent

It read `mem_stats_records[].record_value`, which is a **display number whose unit sits in a separate `record_unit` field the chart never looked at**:

```
HeapAlloc → record_value 6.82,  record_unit "MB"    ← plotted as 6.82
HeapSys   → record_value 1.20,  record_unit "GB"    ← plotted as 1.20
```

Both land on an axis labelled `MB`. `HeapSys` renders five times shorter than `HeapAlloc` while actually being ~180 times larger.

**Being straight about this one:** on the host I tested, every heap figure happens to be in MB, so old and new agree exactly. The chart is correct by luck. The bug appears the moment heap use crosses 1 GB. The fix switches to `raw_mem_stats_records` — already exposed, and in one consistent unit (base-1024 KB) — converted once to MB.

## CPU Statistics pie: summed to twice the core count

`total_cores` was plotted as a slice *alongside* `cores_used_by_service` and `cores_used_by_system` — the denominator as a category of its own pie. The third slice is now idle cores, and the pie sums to the real core count.

## API change

The six raw fields on `models.MemoryStatistics` already existed for internal storage but carried `json:"-"`. Now serialized under explicit names, **additively** — every existing field keeps its shape:

```
total_system_memory_bytes      memory_used_by_service_bytes    stack_memory_usage_bytes
memory_used_by_system_bytes    available_memory_bytes          gc_pause_duration_ms
```

The struct now carries a comment saying why the string fields are unsafe to parse, so the next person reaching for them has the reason in front of them.

## Deliberately not changed

Five `parseFloat` calls remain in `index.js`, reading `load_statistics`. I traced each to its source in `common/metrics.go`: they are all percentage strings (`"0.26%"` — `ParseFloat64ToString(f) + "%"`). Same unit throughout, so parsing them is safe. Blanket-replacing them would have been churn.

## Verification

```
go vet ./...                    clean
go test ./... -race -count=1    all 11 packages pass
node --check static/js/index.js clean
```

Two new API tests assert the raw fields are present, numeric, and **mutually consistent** — a service cannot use more memory than the system total, and `heap_alloc` cannot exceed `heap_sys`. Either failing means the units have diverged again, which is the actual regression to guard against rather than mere field presence.

Checked against a running service in the browser: pie proportions as tabulated above, heap ordering correct with `HeapSys` tallest, CPU pie summing to the actual core count, no console errors. Tooltips now format bytes for display (`12.64 GB (78.97%)`) rather than showing raw counts.

## Note

Branched off `main`, so it does not include the guardrails from #54. No file overlap — the two merge in either order.
