### PR TITLE
chore: renumber the release line to v1 and document releasing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Unformatted memory values on the metrics API: `total_system_memory_bytes`, `memory_used_by_system_bytes`, `memory_used_by_service_bytes`, `available_memory_bytes`, `stack_memory_usage_bytes`, `gc_pause_duration_ms`. Additive -- the existing formatted string fields are unchanged. Anything doing arithmetic on or plotting these metrics must use the raw fields, since the strings carry a unit suffix
 
-## [2.1.0] - 2026-08-28
+## [1.3.0] - 2026-08-28
 
 ### Security
 - `BasicAuthMiddleware` and `APIKeyMiddleware` now compare credentials with `crypto/subtle.ConstantTimeCompare` -- `!=` short-circuits on the first differing byte and leaks length and prefix information to a timing oracle
@@ -55,6 +55,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Argument marshalling shared between `TraceFunctionWithArgs` and `TraceFunctionWithReturns` instead of duplicated
 
 ## [2.0.0] - 2026-02-10
+
+> **Never published.** This release was tagged `v2.0.0`, but the Go module proxy
+> rejects it: `go.mod` declares `module github.com/iyashjayesh/monigo` with no
+> `/v2` suffix, and Go requires the major version to appear in the module path
+> from v2 onwards. `go get` therefore continued to serve `v1.2.0`, and everything
+> below was unreachable to anyone installing the library.
+>
+> ```
+> $ curl -s https://proxy.golang.org/github.com/iyashjayesh/monigo/@v/v2.0.0.info
+> not found: invalid version: module contains a go.mod file, so module path must
+> match major version ("github.com/iyashjayesh/monigo/v2")
+> ```
+>
+> The release line was renumbered rather than renaming the module: `/v2` would be
+> permanent for an API that is not v2-shaped, and per the proxy there were no v2
+> consumers to preserve. The changes below shipped in `1.3.0`.
 
 ### Breaking Changes
 - Renamed `GetRuningPort()` to `GetRunningPort()`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,43 @@ go test ./... -coverprofile=coverage.out
 go tool cover -html=coverage.out
 ```
 
+## Releasing
+
+Maintainers only.
+
+MoniGo is on the **v1 line**. `go.mod` declares
+`module github.com/iyashjayesh/monigo` with no major-version suffix, and Go
+requires the major version to appear in the module path from v2 onwards. A `v2.x`
+tag on this module path is therefore invalid and the proxy will refuse it -- which
+is what happened to `v2.0.0`, leaving `go get` serving `v1.2.0` for months while
+several releases' worth of work sat unreachable.
+
+So: **tag `v1.x.y`, and verify the proxy actually served it.** The second half is
+the step whose absence caused the problem.
+
+```bash
+# 1. CHANGELOG.md: move [Unreleased] entries under a dated version heading
+# 2. tag and push
+git tag -a v1.3.0 -m "v1.3.0"
+git push origin v1.3.0
+
+# 3. VERIFY -- this is not optional
+curl -s https://proxy.golang.org/github.com/iyashjayesh/monigo/@latest
+# must report the version just tagged
+
+# 4. confirm it installs from a clean module
+cd "$(mktemp -d)" && go mod init tmp >/dev/null
+go get github.com/iyashjayesh/monigo@latest && go list -m github.com/iyashjayesh/monigo
+```
+
+If step 3 does not show the new version, the tag is not usable and the release has
+not actually happened, however green the CI run was.
+
+Moving to a v2 line later means renaming the module to
+`github.com/iyashjayesh/monigo/v2` in `go.mod` and updating every import path in
+the examples and README. That is a breaking change for every consumer, so it needs
+a reason beyond the version number looking tidy.
+
 ## Reporting Issues
 
 - Use GitHub Issues for bug reports and feature requests

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -55,13 +55,19 @@ the same hole.
 | **A. Rename module to `.../v2`** | Import-path change in every example, the README, and for anyone consuming v2 via a `replace` directive | Correct SemVer; `v2.x` tags become installable; the existing `v2.0.0` tag stays broken but is superseded |
 | **B. Renumber this release `v1.3.0`** | The `[2.0.0]` changelog entry becomes historically odd | Installable immediately, zero import churn; abandons the 2.x line as never-published |
 
-**Recommendation: B**, then A later if a genuinely breaking change ever justifies
-a major bump. B is one tag and a changelog note. A is a breaking change for users
-who are, per the proxy, currently zero — but it also forces `/v2` into every
-import path forever for a library whose API is not actually v2-shaped.
+**Decision: B.** The release line is renumbered to `v1.3.0`, the `[2.0.0]`
+changelog entry is annotated as never published, and `CONTRIBUTING.md` now carries
+a Releasing section whose verification step is the one whose absence caused this.
 
-Whichever is chosen, the follow-up is the same: **tag it, verify the proxy serves
-it**, and add a release step to `CONTRIBUTING.md` so this cannot silently recur.
+A remains available later, if a genuinely breaking change ever justifies a major
+bump. It was rejected for now because `/v2` would be permanent in every import
+path for an API that is not v2-shaped, and per the proxy there were no v2
+consumers to preserve.
+
+**Still outstanding: the tag itself.** Renumbering the changelog does not publish
+anything. Someone has to run `git tag -a v1.3.0` and confirm the proxy serves it,
+per the checklist in `CONTRIBUTING.md`. Until that happens `go get` continues to
+serve `v1.2.0`.
 
 ---
 


### PR DESCRIPTION
Milestone **A1** from [DEVELOPMENT-PLAN.md](https://github.com/iyashjayesh/monigo/blob/main/DEVELOPMENT-PLAN.md).

## The problem

Nothing released since January is installable.

```
$ curl -s https://proxy.golang.org/github.com/iyashjayesh/monigo/@latest
{"Version":"v1.2.0","Time":"2026-01-23T05:37:43Z", ...}

$ curl -s https://proxy.golang.org/github.com/iyashjayesh/monigo/@v/v2.0.0.info
not found: invalid version: module contains a go.mod file, so module path must
match major version ("github.com/iyashjayesh/monigo/v2")
```

`v2.0.0` is tagged in git, but `go.mod` declares `module github.com/iyashjayesh/monigo` with no `/v2` suffix, and Go requires the major version in the module path from v2 onwards. The proxy refuses the tag, so `go get` has been serving **v1.2.0 from January** — the OTel exporter, structured logging, graceful shutdown, and every fix in the recent hardening work have all been unreachable to anyone installing the library.

## The decision: renumber, don't rename

| | Cost | Result |
| --- | --- | --- |
| Rename module to `.../v2` | `/v2` in every import path, permanently, for every consumer | Correct SemVer |
| **Renumber onto v1** ← taken | The `[2.0.0]` heading reads oddly in hindsight | Installable now, zero import churn |

Renaming puts `/v2` in every import path forever for an API that is not v2-shaped — and per the proxy there are **no v2 consumers** whose imports renaming would preserve. Renumbering costs one tag and a note. Option A stays available later if a genuinely breaking change ever justifies a major bump.

## What this changes

- `2.1.0` → **`1.3.0`**.
- The `[2.0.0]` entry is annotated as never published, with the proxy's own error quoted, so the next person doesn't have to rediscover why.
- `CONTRIBUTING.md` gains a **Releasing** section.
- `ROADMAP.md` Track 0 records the decision.

The important half of the release checklist isn't the tagging command — it's the verification after it:

```bash
curl -s https://proxy.golang.org/github.com/iyashjayesh/monigo/@latest
# must report the version just tagged
```

A tag the proxy refuses is not a release, however green CI was. The absence of that one check is exactly what let this sit unnoticed for months.

## ⚠️ This PR publishes nothing

Renumbering the changelog does not release anything. After merging, someone still has to:

```bash
git tag -a v1.3.0 -m "v1.3.0"
git push origin v1.3.0
# then run the verification above
```

I've deliberately stopped short of tagging — that's the irreversible, public step and it should be a maintainer's call, not something that happens as a side effect of a docs PR. Until it's done, `go get` continues to serve `v1.2.0`.

## Note on ordering

Branched off `main` before #57. If #57 merges first there may be a trivial `CHANGELOG.md` conflict at the `[Unreleased]` heading — both add entries under it. Either order works; the second one merged just needs the two sections kept.
