### PR TITLE
refactor: read card and table colours from the design tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Cards, tables and muted text now read their colours from the design tokens rather than hardcoded hex literals. Colours shift slightly onto the corrected palette and every affected text pair gains contrast -- dark muted text goes from 5.78:1 to 8.38:1, dark card text from 13.34:1 to 14.98:1
+
 ### Added
 - Design token layer in `static/css/monigo-styles.css`: 122 custom properties covering type, spacing, radius, elevation, five surface planes, four ink tones, five semantic states and an eight-colour chart series palette, in matched light and dark sets. Purely additive -- nothing consumes them yet, and removing both rules from the live stylesheet changes the computed style of zero of 713 sampled elements. Every documented contrast ratio is verified: text pairs clear 4.5:1, control borders and the focus ring clear 3:1
 

--- a/DEVELOPMENT-PLAN.md
+++ b/DEVELOPMENT-PLAN.md
@@ -224,7 +224,7 @@ ROADMAP.md Track 2 and the design research behind it.
 | PR | Branch | Scope | Visual diff | Effort |
 | --- | --- | --- | --- | --- |
 | **C1** | `feat/design-tokens` | Add `:root` + `body.dark-theme` token blocks at the top of `monigo-styles.css`. Change nothing else. | **None** | S |
-| **C2** | `refactor/tokenize-cards-tables` | Replace hex literals with tokens for cards and tables. Delete each `!important` the token now wins without. | None | M |
+| **C2** | `refactor/tokenize-cards-tables` | Replace hex literals with tokens for cards and tables. | **Small** (see note) | M |
 | **C3** | `refactor/tokenize-chrome` | Same for sidebar, navbar, buttons, leak panel. | None | M |
 | **C4** | `refactor/collapse-dark-overrides` | Delete each `body.dark-theme` override as its light counterpart becomes tokenized. ~400 of ~440 lines go. | None | M |
 | **C5** | `refactor/borders-not-shadows` | Dark mode uses borders. Drop hover shadows and the `translateY(-2px)` card lift. | Small | S |
@@ -235,6 +235,22 @@ ROADMAP.md Track 2 and the design research behind it.
 
 ### Notes that change how these are reviewed
 
+- **C2 does not have zero visual diff, and cannot delete `!important` yet.** Both
+  claims in the original plan were wrong, and testing found it. The tokens are a
+  *corrected* palette, not a restatement of the current literals: 6 of the 8
+  dominant values shift. The moves are small -- most under 20 on a 0-441 scale --
+  and every affected text pair gains contrast (dark muted text 5.78:1 -> 8.38:1),
+  but "None" was the wrong expectation to set for a reviewer. On `!important`:
+  removing all 64 flags from the card and table rules changes nothing in light
+  theme, but 7 elements in dark depend on one of them
+  (`body.dark-theme .card { color }`), where the vendored `.bg-success` rule wins
+  otherwise. Removing them safely needs per-declaration verification, and is
+  better done in C4 once the vendored dark overrides are gone.
+- **Measuring a CSS change needs a settle delay after any theme toggle.** An
+  earlier C2 measurement reported 21 changed elements; the fingerprint had been
+  captured mid-transition, and the "change" was the theme finishing. With a
+  1s settle it reproduces as 0. Any before/after comparison in C3-C9 needs the
+  same care, or it will invent regressions.
 - **C1 is the safest PR in this plan and the highest leverage.** Zero visual
   diff — it only adds declarations. Merge it early even if C2 stalls.
 - **C4 is where the `!important` count should collapse.** Quote before/after counts

--- a/static/css/monigo-styles.css
+++ b/static/css/monigo-styles.css
@@ -365,7 +365,7 @@ body.dark-theme {
 /* Global Premium Styling Overrides */
 .card {
     border-radius: 12px !important;
-    border: 1px solid #e5e7eb !important;
+    border: 1px solid var(--hairline) !important;
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -1px rgba(0, 0, 0, 0.03) !important;
     transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1), box-shadow 0.25s cubic-bezier(0.4, 0, 0.2, 1), border-color 0.25s ease !important;
 }
@@ -474,9 +474,9 @@ body.dark-theme .iq-sidebar-menu ul li a:hover svg {
 }
 
 body.dark-theme .card {
-    background-color: #111827 !important;
-    border: 1px solid #1f2937 !important;
-    color: #f3f4f6 !important;
+    background-color: var(--surface-1) !important;
+    border: 1px solid var(--hairline) !important;
+    color: var(--ink) !important;
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.4), 0 2px 4px -1px rgba(0, 0, 0, 0.2) !important;
 }
 
@@ -487,9 +487,9 @@ body.dark-theme .card:hover {
 
 body.dark-theme .card-header,
 body.dark-theme .card-footer {
-    background-color: #1f2937 !important;
-    border-bottom: 1px solid #374151 !important;
-    color: #f3f4f6 !important;
+    background-color: var(--surface-2) !important;
+    border-bottom: 1px solid var(--hairline) !important;
+    color: var(--ink) !important;
 }
 
 body.dark-theme .iq-top-navbar {
@@ -508,24 +508,25 @@ body.dark-theme .navbar-list {
 
 body.dark-theme .text-muted,
 body.dark-theme .dropdown-label {
-    color: #9ca3af !important;
+    color: var(--ink-muted) !important;
 }
 
 body.dark-theme .table {
-    color: #f3f4f6 !important;
+    color: var(--ink) !important;
 }
 
 body.dark-theme .table th {
-    border-color: #1f2937 !important;
-    background-color: #1f2937 !important;
+    border-color: var(--hairline) !important;
+    background-color: var(--surface-3) !important;
 }
 
 body.dark-theme .table td {
-    border-color: #1f2937 !important;
+    /* A quieter rule than the table's own edge, so rows read as rows. */
+    border-color: var(--hairline-soft) !important;
 }
 
 body.dark-theme .table tbody tr:hover {
-    background-color: #1f2937 !important;
+    background-color: var(--surface-3) !important;
 }
 
 body.dark-theme .modal-content {


### PR DESCRIPTION
Milestone **C2** from [DEVELOPMENT-PLAN.md](https://github.com/iyashjayesh/monigo/blob/main/DEVELOPMENT-PLAN.md). Refs #32.

Five rule groups move onto the token layer from #59: the light card border, the dark card, the dark card header/footer, the dark table (body, header cells, data cells, row hover), and the muted text tone used for every secondary label inside them.

Hex literals outside the token block: **105 → 92**.

## The plan was wrong twice, and testing found it

I've corrected both claims in `DEVELOPMENT-PLAN.md` rather than quietly shipping around them.

### 1. This is not a zero-diff change

The tokens are a *corrected* palette, not a restatement of the current literals — **6 of the 8 dominant values shift**. The moves are small (most under 20 on a 0–441 scale; largest is muted text at 38), and every affected text pair **gains** contrast:

| | before | after |
| --- | --- | --- |
| dark muted text on card | 5.78:1 | **8.38:1** |
| dark heading on card | 13.34:1 | **14.98:1** |
| dark muted on page ground | 6.99:1 | **9.11:1** |

Small and improving — but "None" was the wrong expectation to set for a reviewer.

### 2. The `!important` flags cannot come off yet

Removing all 64 across these rules changes nothing in light theme. But **7 elements in dark depend on one of them**: without the flag on `body.dark-theme .card { color }`, the vendored `.bg-success` rule wins and the sidebar card's text reverts to green (`rgb(64,135,89)`).

Removing the rest safely needs per-declaration verification, which belongs in C4 once the vendored dark overrides are gone — not guesswork here. The count stays at 205.

## Verified live, not asserted

Measured in the browser against a running service:

```
card background   #14171d   = --surface-1   ✓
card border       #2c323d   = --hairline    ✓
card text         16.29:1   = --ink         ✓ matches the documented ratio
muted text         9.11:1   = --ink-muted   ✓ matches the documented ratio
```

## A methodology note worth reading

An earlier measurement of this change reported **21 changed elements**, and I nearly wrote it up as "the vendored template still wins". It was an artifact: the baseline fingerprint was captured immediately after clicking the theme toggle, so it caught the page mid-transition and attributed the theme *finishing* to my edit. With a 1s settle delay it reproduces as **0**.

This is recorded in the plan because it will bite again — every before/after CSS comparison in C3–C9 needs the same care, or it will invent regressions that don't exist.

## Deliberately untouched

`.card` still carries `border-radius: 12px` against the token scale's 10px, and its own shadow rather than `--sh-1`. Both belong to **C5**; folding them in would have made this diff about three things instead of one.

## Verification

```
go vet ./...                    clean
go test ./... -race -count=1    all 11 packages pass
guardrails                      payload within budget, no new external deps
```
