### PR TITLE
feat: put type and density on the design's scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Type and density follow the design's scale.** Metric tiles are now an uppercase micro-label over one large tabular number, card titles and body text sit on a six-step scale topping out at 24px rather than the vendored template's defaults, card padding is 16px, and table rows are tighter with a sticky header. Every `font-size` and `border-radius` in the project stylesheet now comes from a token: 12 ad-hoc sizes and 5 ad-hoc radii reduced to 6 and 3
+- Metric labels drop their trailing colons, since an uppercase eyebrow does not take one
 - **The dashboard adopts the new design's palette and collapses the dark theme onto it.** Colours now come from the design system: a cyan accent (`#00B4E6` dark / `#00758F` light) replacing the orange, five surface planes per theme, and five semantic states. Hex literals in real declarations drop from 105 to 2; `body.dark-theme` component rules from 53 to 3. Every text pair clears WCAG AA and every control boundary clears 3:1, verified in a running dashboard in both themes
 - Focus rings restored. The vendored `.btn:focus { outline: none; box-shadow: none }` stripped every focus indicator with no replacement, so tabbing the dashboard moved nothing visually
 - Stack traces and pprof output render in IBM Plex Mono at a fixed size on a recessed surface. The previous rule asked for `'Fira Code'`, which is not shipped and never resolved

--- a/static/css/monigo-styles.css
+++ b/static/css/monigo-styles.css
@@ -325,10 +325,10 @@ body.dark-theme {
 
 .dropdown-select {
     border: 1px solid var(--hairline-strong);
-    border-radius: 10px;
+    border-radius: var(--r-lg);
     padding: 0.4rem;
     background: var(--surface-1);
-    font-size: 1rem;
+    font-size: var(--t-body);
     cursor: pointer;
 }
 
@@ -345,7 +345,7 @@ body.dark-theme {
 
 /* Global Premium Styling Overrides */
 .card {
-    border-radius: 12px !important;
+    border-radius: var(--r-lg) !important;
     border: 1px solid var(--hairline) !important;
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -1px rgba(0, 0, 0, 0.03) !important;
     transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1), box-shadow 0.25s cubic-bezier(0.4, 0, 0.2, 1), border-color 0.25s ease !important;
@@ -382,7 +382,7 @@ body.dark-theme {
 /* Modern Progress Bars */
 .iq-progress-bar {
     height: 7px !important;
-    border-radius: 6px !important;
+    border-radius: var(--r-md) !important;
     background: var(--surface-2) !important;
     overflow: hidden !important;
     margin-top: 12px !important;
@@ -391,14 +391,14 @@ body.dark-theme {
 
 .iq-progress {
     height: 100% !important;
-    border-radius: 6px !important;
+    border-radius: var(--r-md) !important;
     display: block !important;
     background-color: var(--accent) !important;
 }
 
 /* Icon Box Polish */
 .iq-icon-box-2 {
-    border-radius: 10px !important;
+    border-radius: var(--r-lg) !important;
     display: inline-flex !important;
     align-items: center !important;
     justify-content: center !important;
@@ -679,6 +679,115 @@ pre {
     background: var(--accent-tint) !important;
 }
 
+/* --- Type scale and density ------------------------------------------------
+
+   The design runs 10-16px with no display tier, which is denser than the
+   vendored template's defaults and correct for a screen an operator scans for
+   what is wrong. These rules bring the actual elements onto the token scale;
+   the tokens themselves were added earlier but nothing consumed them.
+
+   The metric card pattern is `<p class="mb-2">Label</p><h4>value</h4>` inside
+   `.card-body`, rendered by updateElement() in index.js. The design's version
+   of that is an uppercase micro-label over one large number, which is what the
+   two rules below produce.
+   -------------------------------------------------------------------------- */
+
+body {
+    font-size: var(--t-body);
+    line-height: var(--t-body-lh);
+}
+
+/* Metric tile label: uppercase eyebrow, not sentence case. */
+.card-body .card-total-sale p.mb-2,
+.card-body > div > div > p.mb-2 {
+    font-size: var(--t-micro) !important;
+    font-weight: var(--t-micro-w) !important;
+    line-height: var(--t-micro-lh) !important;
+    letter-spacing: .09em !important;
+    text-transform: uppercase !important;
+    color: var(--ink-subtle) !important;
+    margin-bottom: var(--s-2) !important;
+}
+
+/* Metric tile value: the one big number per tile. */
+.card-body .card-total-sale h4,
+.card-body > div > div > h4 {
+    font-size: var(--t-stat) !important;
+    font-weight: var(--t-stat-w) !important;
+    line-height: var(--t-stat-lh) !important;
+    letter-spacing: -.01em !important;
+    color: var(--ink) !important;
+    font-variant-numeric: tabular-nums;
+    margin-bottom: 0 !important;
+}
+
+/* A skeleton value is a placeholder, not a statistic: keep it at the label's
+   weight so a connecting dashboard does not look like it is reporting. */
+.card-body h4.skeleton-text {
+    font-size: var(--t-head) !important;
+    font-weight: var(--t-head-w) !important;
+    letter-spacing: 0 !important;
+}
+
+.card-title,
+.card-header h4,
+.card-header h5 {
+    font-size: var(--t-head) !important;
+    font-weight: var(--t-head-w) !important;
+    line-height: var(--t-head-lh) !important;
+    letter-spacing: -.005em !important;
+    color: var(--ink) !important;
+}
+
+/* Card chrome. 16px padding on a metric tile, never 24px+: the tile exists to
+   show a number, and the number should dominate it. */
+.card-body {
+    padding: var(--s-5) !important;
+}
+
+.card-header {
+    padding: var(--s-4) var(--s-5) !important;
+    min-height: 0 !important;
+}
+
+/* Tables. 34px rows: 6px cell padding either side of a 20px line box plus the
+   rule. Sticky header so column meaning survives a long scroll. */
+.table th {
+    padding: var(--s-2) var(--s-4) !important;
+    position: sticky;
+    top: 0;
+    z-index: 2;
+}
+
+.table td {
+    padding: var(--s-2) var(--s-4) !important;
+    line-height: var(--t-body-lh) !important;
+}
+
+/* Radius. The design uses 12 distinct values; this is the three-step scale.
+   Everything that was 20px was a pill on a rectangular thing. */
+.card,
+.modal-content {
+    border-radius: var(--r-lg) !important;
+}
+
+.btn,
+.btn-primary,
+.dropdown-select,
+.iq-icon-box-2,
+pre,
+#download-image-btn,
+#download-stack-view,
+#downloadBtn {
+    border-radius: var(--r-md) !important;
+}
+
+.badge,
+.info-icon,
+.leak-badge {
+    border-radius: var(--r-sm) !important;
+}
+
 /* --- Dark theme: structural exceptions only -------------------------------
 
    Everything above is theme-agnostic. What remains changes a *property*
@@ -752,15 +861,15 @@ body {
 }
 
 .navbar-list li.nav-item.nav-icon.dropdown a i.fa-github {
-    font-size: 18px !important;
+    font-size: var(--t-head) !important;
     margin: 0 !important;
 }
 
 /* Countdown Pill Style */
 .add-btn {
-    border-radius: 20px !important;
+    border-radius: var(--r-lg) !important;
     padding: 6px 16px !important;
-    font-size: 13px !important;
+    font-size: var(--t-body) !important;
     font-weight: 500 !important;
     background-color: transparent !important;
     border-color: var(--hairline-strong) !important;
@@ -790,7 +899,7 @@ body {
     border: 1px solid var(--accent) !important;
     color: var(--accent-text) !important;
     font-weight: 500 !important;
-    font-size: 13px !important;
+    font-size: var(--t-body) !important;
     padding: 6px 14px !important;
     box-shadow: none !important;
     transition: all 0.2s ease-in-out !important;
@@ -805,13 +914,13 @@ body {
 .sidebar-bottom .card.bg-success-light {
     background-color: rgba(255, 255, 255, 0.04) !important;
     border: 1px solid rgba(255, 255, 255, 0.08) !important;
-    border-radius: 12px !important;
+    border-radius: var(--r-lg) !important;
     margin: 15px !important;
 }
 
 .sidebar-bottom .card.bg-success-light h6 {
     color: var(--ink-subtle) !important;
-    font-size: 12px !important;
+    font-size: var(--t-meta) !important;
     line-height: 1.6 !important;
     font-weight: 400 !important;
 }
@@ -820,7 +929,7 @@ body {
     background-color: var(--accent) !important;
     border: none !important;
     width: 100% !important;
-    border-radius: 8px !important;
+    border-radius: var(--r-md) !important;
     padding: 8px 12px !important;
     transition: all 0.2s ease-in-out !important;
 }
@@ -828,7 +937,7 @@ body {
 .sidebar-bottom .card.bg-success-light .sidebar-bottom-btn a {
     color: var(--accent-on-fill) !important;
     font-weight: 600 !important;
-    font-size: 13px !important;
+    font-size: var(--t-body) !important;
     text-decoration: none !important;
 }
 
@@ -845,7 +954,7 @@ body {
 /* Harmonize icon box colors with brand orange */
 .iq-icon-box-2 {
     background-color: color-mix(in srgb, var(--accent) 6%, transparent) !important;
-    border-radius: 10px !important;
+    border-radius: var(--r-lg) !important;
     width: 44px !important;
     height: 44px !important;
     display: inline-flex !important;
@@ -876,14 +985,14 @@ body {
     gap: 10px;
     flex-wrap: wrap;
     padding: 14px 18px;
-    border-radius: 10px;
-    font-size: 14px;
+    border-radius: var(--r-lg);
+    font-size: var(--t-body);
     line-height: 1.5;
     border: 1px solid transparent;
 }
 
 .leak-status i {
-    font-size: 16px;
+    font-size: var(--t-head);
     flex-shrink: 0;
 }
 
@@ -900,7 +1009,7 @@ body {
 }
 
 .leak-meta {
-    font-size: 12px;
+    font-size: var(--t-meta);
     opacity: 0.75;
     margin-left: auto;
 }
@@ -930,9 +1039,9 @@ body {
 .leak-badge {
     background: var(--warn-fill);
     color: var(--accent-on-fill);
-    border-radius: 20px;
+    border-radius: var(--r-lg);
     padding: 2px 10px;
-    font-size: 12px;
+    font-size: var(--t-meta);
     font-weight: 700;
     flex-shrink: 0;
 }
@@ -945,7 +1054,7 @@ body {
 }
 
 .leak-reasons {
-    font-size: 12px;
+    font-size: var(--t-meta);
     opacity: 0.8;
     margin-left: auto;
 }
@@ -953,7 +1062,7 @@ body {
 .leak-stack {
     margin: 0;
     padding: 12px 14px;
-    font-size: 12px;
+    font-size: var(--t-meta);
     line-height: 1.5;
     max-height: 220px;
     overflow: auto;

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -121,7 +121,7 @@ document.addEventListener('DOMContentLoaded', () => {
             if (el) {
                 el.innerHTML = `
                     <div>
-                        <p class="mb-2 text-muted">${label} <span class="info-icon" data-tooltip="${info}">i</span></p>
+                        <p class="mb-2 text-muted">${label.replace(/:\s*$/, '')} <span class="info-icon" data-tooltip="${info}">i</span></p>
                         <h4 class="skeleton-text animate-pulse text-muted">Connecting...</h4>
                     </div>`;
             }
@@ -131,7 +131,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (sName) {
             sName.innerHTML = `
                 <div class="mt-1">
-                    <p class="mb-2 text-muted">Service Name:</p>
+                    <p class="mb-2 text-muted">Service Name</p>
                     <h4 class="skeleton-text animate-pulse text-muted">Connecting...</h4>
                 </div>`;
         }
@@ -139,7 +139,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (gVer) {
             gVer.innerHTML = `
                 <div class="mt-1">
-                    <p class="mb-2 text-muted">Go Version:</p>
+                    <p class="mb-2 text-muted">Go Version</p>
                     <h4 class="skeleton-text animate-pulse text-muted">Connecting...</h4>
                 </div>`;
         }
@@ -147,7 +147,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (sStart) {
             sStart.innerHTML = `
                 <div class="mt-1">
-                    <p class="mb-2 text-muted">Service Start Time:</p>
+                    <p class="mb-2 text-muted">Service Start Time</p>
                     <h4 class="skeleton-text animate-pulse text-muted">Connecting...</h4>
                 </div>`;
         }
@@ -155,7 +155,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (pId) {
             pId.innerHTML = `
                 <div class="mt-1">
-                    <p class="mb-2 text-muted">Process ID:</p>
+                    <p class="mb-2 text-muted">Process ID</p>
                     <h4 class="skeleton-text animate-pulse text-muted">Connecting...</h4>
                 </div>`;
         }
@@ -207,23 +207,23 @@ document.addEventListener('DOMContentLoaded', () => {
                 service_name.innerHTML = `
                     <div class="d-flex align-items-center mb-4 card-total-sale">
                         <div>
-                            <p class="mb-2">Service Name: <h4>${data.service_name}</h4></p>
+                            <p class="mb-2">Service Name <h4>${data.service_name}</h4></p>
                         </div>
                     </div>`;
                 go_version.innerHTML = `
                     <div class="d-flex align-items-center mb-4 card-total-sale">
                         <div>
-                            <p class="mb-2">Go Version: <h4>${data.go_version}</h4></p>
+                            <p class="mb-2">Go Version <h4>${data.go_version}</h4></p>
                         </div>
                     </div>`;
                 service_start_time.innerHTML = `
                  <div>
-                    <p class="mb-2">Service Start Time: <h4>${formattedDate}<br/> ${formattedTime}</h4></p>
+                    <p class="mb-2">Service Start Time <h4>${formattedDate}<br/> ${formattedTime}</h4></p>
                 </div>`;
 
                 process_id.innerHTML = `
                  <div>
-                    <p class="mb-2">Process ID: <h4>${data.process_id}</h4></p>
+                    <p class="mb-2">Process ID <h4>${data.process_id}</h4></p>
                 </div>`;
             });
     }
@@ -232,7 +232,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (element) {
             element.innerHTML = `
                 <div>
-                    <p class="mb-2">${label} <span class="info-icon" data-tooltip="${info}">i</span></p>
+                    <p class="mb-2">${label.replace(/:\s*$/, '')} <span class="info-icon" data-tooltip="${info}">i</span></p>
                     <h4>${value}</h4>
                 </div>`;
 
@@ -260,12 +260,12 @@ document.addEventListener('DOMContentLoaded', () => {
                 elements.coreUsageDetailButton.innerHTML = `
                     <div class="d-flex align-items-center mb-1 card-total-sale">
                         <div>
-                            <p class="mb-2">Total Cores: <h4>${obj.total_cores}</h4></p>
+                            <p class="mb-2">Total Cores <h4>${obj.total_cores}</h4></p>
                         </div>
                     </div>
                     <div class="d-flex align-items-center mb-1 card-total-sale">
                         <div>
-                            <p class="mb-2">Total Logical Cores: <h4>${obj.total_logical_cores}</h4></p>
+                            <p class="mb-2">Total Logical Cores <h4>${obj.total_logical_cores}</h4></p>
                         </div>
                     </div>
                     <div class="d-flex align-items-center mb-1 card-total-sale">


### PR DESCRIPTION
Milestone **D2** from [DESIGN-ADOPTION.md](https://github.com/iyashjayesh/monigo/blob/main/DESIGN-ADOPTION.md). Refs #32.

The type tokens landed with the palette in #61, but nothing consumed them — sizes still came from the vendored template's defaults, which are tuned for a marketing page rather than a screen someone scans for what is wrong.

## The scale, applied

The design runs 10–16px with no display tier. Reduced to six named steps and applied to the elements that actually render:

| | token | |
| --- | --- | --- |
| metric label | `--t-micro` | 10px, uppercase, .09em tracking, `--ink-subtle` |
| metric value | `--t-stat` | 24px, 600, `tabular-nums`, `--ink` |
| card title | `--t-head` | 15px |
| body, table cells | `--t-body` | 13px |

The metric tile pattern is `<p class="mb-2">Label</p><h4>value</h4>` from `updateElement()` in `index.js`, so two rules turn every tile into the design's uppercase-eyebrow-over-one-number treatment **without touching the markup**.

## Two details worth the reviewer's attention

**Labels lose their trailing colons** — an uppercase eyebrow doesn't take one. The colon is stripped *at render time* rather than from the label strings, because those are compared by value in three places:

```js
if (label == 'Memory:')   if (label == 'Cores:')   if (label == 'Load:')
```

Editing the strings would have silently broken all three Detailed View modals.

**A skeleton value stays at `--t-head`, not `--t-stat`.** A placeholder rendered at statistic size makes a still-connecting dashboard look like it's reporting.

## Density and shape

16px card padding, 12/16px card headers, tighter table cells, and a **sticky table header** so column meaning survives a long scroll.

Every `font-size` and `border-radius` in the project stylesheet is now a token:

```
ad-hoc font sizes   12 → 6
ad-hoc radii         5 → 3
```

Everything that was `20px` was a pill applied to a rectangle.

## On the webfont

The stack declares IBM Plex first and falls back to the system stack, so the woff2 files can be added later as a **drop-in with no CSS change**. They aren't shipped here — that decision is still open — so today the dashboard renders in the fallback. That's deliberate: it means the decision doesn't block this PR either way.

## Verification

Measured in a running dashboard:

```
label   10px, uppercase, 0.9px tracking
value   24px, weight 600, tabular-nums
title   15px
padding 16px      radius 12px      body 13px
```

Both themes, all four pages, no console errors.

```
go vet ./...                    clean
go test ./... -race -count=1    all 11 packages pass
node --check                    all non-vendored dashboard JS parses
```

## Not in this PR

The shell and Overview *layout* (200px sidebar, tile grid, sparkline tiles, threshold bars) is D3. This PR changes type, spacing and shape within the existing layout — the structure is still the vendored template's.
