### PR TITLE
feat: adopt the design's shell — identity, grouped nav, storage footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **The sidebar gains the design's shell**: a service identity block (name, PID, Go version and a connection dot), a `MONITOR` section label above the navigation, live counts on the Function Metrics and Go Routines items, and a storage footer showing the backend, retention window and on-disk footprint. All of it is chrome -- true of the instrument rather than of any one page -- so every page shows it and no page fetches it twice
+- `/service-info` exposes `retention_period`, `storage_type` and `storage_on_disk`. `storage_on_disk` is omitted for the in-memory backend, since reporting `0 B` there would read as "nothing stored" rather than "not applicable"
+- `common.GetRetentionPeriodString()` and `timeseries.GetStorageType()`
+
 ## [1.4.0] - 2026-08-28
 
 ### Added

--- a/api/api.go
+++ b/api/api.go
@@ -30,8 +30,17 @@ func GetServiceInfoAPI(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
+	info := common.GetServiceInfo()
+	info.RetentionPeriod = common.GetRetentionPeriodString()
+	info.StorageType = timeseries.GetStorageType()
+	if info.StorageType == "disk" {
+		// Only meaningful for the disk backend; the in-memory one has no
+		// footprint to report and reporting 0 B would read as "nothing stored".
+		info.StorageOnDisk = common.GetDirSize(common.GetBasePath())
+	}
+
 	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(common.GetServiceInfo()); err != nil {
+	if err := json.NewEncoder(w).Encode(info); err != nil {
 		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
 	}
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -307,3 +307,46 @@ func TestServiceMetricsExposesRawHeapRecords(t *testing.T) {
 		}
 	}
 }
+
+// The dashboard chrome shows retention and storage footprint in the sidebar,
+// because they are properties of the instrument rather than of any one metric.
+// Both are omitted when unset rather than reported as zero, since "not
+// configured" and "zero" are different states.
+func TestServiceInfoExposesStorageFootprint(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/monigo/api/v1/service-info", nil)
+	w := httptest.NewRecorder()
+	GetServiceInfoAPI(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var info map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&info); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	// The fields the sidebar identity block reads.
+	for _, field := range []string{"service_name", "process_id", "go_version"} {
+		if _, ok := info[field]; !ok {
+			t.Errorf("service-info is missing %q, which the sidebar identity needs", field)
+		}
+	}
+
+	// storage_type is always known: it defaults to "disk".
+	st, ok := info["storage_type"].(string)
+	if !ok || st == "" {
+		t.Errorf("storage_type = %v, want a non-empty string", info["storage_type"])
+	}
+	if st != "disk" && st != "memory" {
+		t.Errorf("storage_type = %q, want \"disk\" or \"memory\"", st)
+	}
+
+	// The on-disk figure is only meaningful for the disk backend; reporting
+	// "0 B" for the in-memory one would read as "nothing stored".
+	if st == "memory" {
+		if v, present := info["storage_on_disk"]; present {
+			t.Errorf("storage_on_disk = %v for the memory backend; it should be omitted", v)
+		}
+	}
+}

--- a/common/common.go
+++ b/common/common.go
@@ -4,8 +4,8 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io"
 	"github.com/iyashjayesh/monigo/internal/logger"
+	"io"
 	"math"
 	"os"
 	"path/filepath"
@@ -20,7 +20,7 @@ import (
 const monigoFolder string = "monigo"
 
 var (
-	serviceInfo      models.ServiceInfo
+	serviceInfo     models.ServiceInfo
 	retentionPeriod string
 )
 
@@ -262,6 +262,13 @@ func GetServiceStartTime() time.Time {
 // GetServiceName returns the configured service name.
 func GetServiceName() string {
 	return serviceInfo.ServiceName
+}
+
+// GetRetentionPeriodString returns the retention period exactly as configured,
+// e.g. "7d". GetDataRetentionPeriod parses the same value into a duration; this
+// is for display, where "7d" reads better than "168h0m0s".
+func GetRetentionPeriodString() string {
+	return retentionPeriod
 }
 
 // parseDuration parses the duration string.

--- a/models/models.go
+++ b/models/models.go
@@ -10,6 +10,14 @@ type ServiceInfo struct {
 	ServiceStartTime time.Time `json:"service_start_time"`
 	GoVersion        string    `json:"go_version"`
 	ProcessId        int32     `json:"process_id"`
+
+	// Storage footprint. Retention and where the data lives are properties of
+	// the instrument rather than of any one metric, so the dashboard shows them
+	// in its chrome. Both are omitted when unset rather than reported as zero,
+	// since "0s retention" and "not configured" are different states.
+	RetentionPeriod string `json:"retention_period,omitempty"`
+	StorageType     string `json:"storage_type,omitempty"`
+	StorageOnDisk   string `json:"storage_on_disk,omitempty"`
 }
 
 // ServiceHealthThresholds is the struct to store the service health thresholds

--- a/static/css/monigo-styles.css
+++ b/static/css/monigo-styles.css
@@ -1125,3 +1125,170 @@ body {
     height: 22px;
     cursor: pointer;
 }
+
+/* --- Shell: sidebar identity, grouped navigation, storage footer ------------
+
+   The design puts three things in the sidebar that the template did not have:
+   what service you are looking at, section labels above the navigation, and
+   the retention footprint. All three are chrome -- true of the whole
+   instrument rather than of any one page -- so they live here rather than on
+   the Overview.
+
+   The template's own hooks are untouched: .iq-sidebar, .iq-sidebar-logo,
+   .data-scrollbar, #iq-sidebar-toggle and .wrapper-menu all still work, so the
+   mobile toggle and scroll behaviour survive.
+   -------------------------------------------------------------------------- */
+
+.iq-sidebar {
+    width: 226px !important;
+}
+
+/* Service identity ------------------------------------------------------- */
+
+.mg-identity {
+    display: flex;
+    align-items: center;
+    gap: var(--s-3);
+    padding: var(--s-4) var(--s-5);
+    border-bottom: 1px solid var(--hairline);
+}
+
+.mg-identity-avatar {
+    width: 26px;
+    height: 26px;
+    flex: none;
+    display: grid;
+    place-items: center;
+    border-radius: var(--r-sm);
+    background: var(--accent-tint);
+    color: var(--accent);
+    font-family: var(--font-mono);
+    font-size: var(--t-micro);
+    font-weight: 600;
+    text-transform: lowercase;
+}
+
+.mg-identity-text {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    line-height: 1.25;
+}
+
+.mg-identity-name {
+    font-size: var(--t-body);
+    font-weight: 600;
+    color: var(--ink);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.mg-identity-meta {
+    font-family: var(--font-mono);
+    font-size: var(--t-micro);
+    color: var(--ink-subtle);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* Connected until proven otherwise; common.js flips it on a failed poll. */
+.mg-identity-dot {
+    width: 6px;
+    height: 6px;
+    flex: none;
+    margin-left: auto;
+    border-radius: 50%;
+    background: var(--ok-fill);
+}
+
+.mg-identity-dot.is-stale {
+    background: var(--warn-fill);
+}
+
+.mg-identity-dot.is-down {
+    background: var(--crit-fill);
+}
+
+/* Grouped navigation ----------------------------------------------------- */
+
+.mg-navlabel {
+    padding: var(--s-5) var(--s-5) var(--s-2);
+    font-family: var(--font-mono);
+    font-size: var(--t-micro);
+    font-weight: var(--t-micro-w);
+    letter-spacing: .12em;
+    color: var(--ink-subtle);
+    list-style: none;
+}
+
+.mg-badge {
+    margin-left: auto;
+    padding: 1px var(--s-2);
+    border-radius: var(--r-sm);
+    background: var(--surface-3);
+    color: var(--ink-subtle);
+    font-family: var(--font-mono);
+    font-size: var(--t-micro);
+    line-height: 16px;
+    font-variant-numeric: tabular-nums;
+}
+
+.iq-sidebar-menu ul li.active > a .mg-badge {
+    background: var(--accent-tint);
+    color: var(--accent);
+}
+
+/* The nav link is a flex row so the badge can sit hard right. The icons need
+   an explicit basis: without it a flex row collapses an <svg> with no intrinsic
+   width to 1px, which is what happened to the goroutines icon. */
+.iq-sidebar-menu ul li a {
+    display: flex !important;
+    align-items: center;
+    gap: var(--s-2);
+}
+
+.iq-sidebar-menu ul li a > svg {
+    flex: none;
+    width: 20px;
+    height: 20px;
+}
+
+/* The label takes the slack so the badge lands hard right. Growing the label
+   is cleaner than `margin-left: auto` on the badge, which the vendored rules
+   override. */
+.iq-sidebar-menu ul li a > .ml-4 {
+    flex: 1 1 auto;
+    margin-left: var(--s-2) !important;
+}
+
+/* A badge with nothing in it is noise. */
+.mg-badge:empty {
+    display: none;
+}
+
+/* Storage footer --------------------------------------------------------- */
+
+.mg-storage {
+    margin: var(--s-5) var(--s-5) var(--s-3);
+    padding-top: var(--s-4);
+    border-top: 1px solid var(--hairline);
+}
+
+.mg-storage-head {
+    display: flex;
+    justify-content: space-between;
+    font-family: var(--font-mono);
+    font-size: var(--t-micro);
+    letter-spacing: .12em;
+    color: var(--ink-subtle);
+    margin-bottom: var(--s-2);
+}
+
+.mg-storage-value {
+    font-family: var(--font-mono);
+    font-size: var(--t-meta);
+    color: var(--ink-muted);
+    font-variant-numeric: tabular-nums;
+}

--- a/static/function-metrics.html
+++ b/static/function-metrics.html
@@ -52,9 +52,22 @@
                     <svg class="icon wrapper-menu" aria-hidden="true"><use href="#i-menu"></use></svg>
                 </div>
             </div>
+            <!-- Service identity. The design puts what you are looking at above
+                 the navigation, so the page answers "which service is this?"
+                 without a round trip. Populated by common.js. -->
+            <div class="mg-identity">
+                <div class="mg-identity-avatar" id="mg-avatar">--</div>
+                <div class="mg-identity-text">
+                    <span class="mg-identity-name" id="mg-service-name">&nbsp;</span>
+                    <span class="mg-identity-meta" id="mg-service-meta">&nbsp;</span>
+                </div>
+                <span class="mg-identity-dot" id="mg-status-dot" title="Connected"></span>
+            </div>
+
             <div class="data-scrollbar" data-scroll="1">
                 <nav class="iq-sidebar-menu">
                     <ul id="iq-sidebar-toggle" class="iq-menu">
+                        <li class="mg-navlabel">MONITOR</li>
                         <li class=" ">
                             <a href="./index.html" class="svg-icon">
                                 <svg class="svg-icon" id="p-dash1" width="20" height="20" xmlns="http://www.w3.org/2000/svg"
@@ -79,7 +92,7 @@
                                     <polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline>
                                     <line x1="12" y1="22.08" x2="12" y2="12"></line>
                                 </svg>
-                                <span class="ml-4">Function Metrics</span>
+                                <span class="ml-4">Function Metrics</span><span class="mg-badge" id="mg-count-functions"></span>
                             </a>
                         </li>
                         <li class=" ">
@@ -93,7 +106,7 @@
                                     <polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline>
                                     <line x1="12" y1="22.08" x2="12" y2="12"></line>
                                 </svg>
-                                <span class="ml-4">Go Routines Stats</span>
+                                <span class="ml-4">Go Routines Stats</span><span class="mg-badge" id="mg-count-goroutines"></span>
                             </a>
                         </li>
                         <li class=" ">
@@ -114,6 +127,13 @@
                         </li>
                     </ul>
                 </nav>
+                <div class="mg-storage">
+                    <div class="mg-storage-head">
+                        <span>STORAGE</span>
+                        <span id="mg-storage-mode">&nbsp;</span>
+                    </div>
+                    <div class="mg-storage-value" id="mg-storage-value">&nbsp;</div>
+                </div>
                 <div id="sidebar-bottom" class="position-relative sidebar-bottom">
                     <div class="card border-none border-radius-20 p-2 bg-success-light">
                         <div class="card-body">

--- a/static/go-routines-stats.html
+++ b/static/go-routines-stats.html
@@ -55,9 +55,22 @@
                     <svg class="icon wrapper-menu" aria-hidden="true"><use href="#i-menu"></use></svg>
                 </div>
             </div>
+            <!-- Service identity. The design puts what you are looking at above
+                 the navigation, so the page answers "which service is this?"
+                 without a round trip. Populated by common.js. -->
+            <div class="mg-identity">
+                <div class="mg-identity-avatar" id="mg-avatar">--</div>
+                <div class="mg-identity-text">
+                    <span class="mg-identity-name" id="mg-service-name">&nbsp;</span>
+                    <span class="mg-identity-meta" id="mg-service-meta">&nbsp;</span>
+                </div>
+                <span class="mg-identity-dot" id="mg-status-dot" title="Connected"></span>
+            </div>
+
             <div class="data-scrollbar" data-scroll="1">
                 <nav class="iq-sidebar-menu">
                     <ul id="iq-sidebar-toggle" class="iq-menu">
+                        <li class="mg-navlabel">MONITOR</li>
                         <li class=" ">
                             <a href="./index.html" class="svg-icon">
                                 <svg class="svg-icon" id="p-dash1" width="20" height="20" xmlns="http://www.w3.org/2000/svg"
@@ -82,7 +95,7 @@
                                     <polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline>
                                     <line x1="12" y1="22.08" x2="12" y2="12"></line>
                                 </svg>
-                                <span class="ml-4">Function Metrics</span>
+                                <span class="ml-4">Function Metrics</span><span class="mg-badge" id="mg-count-functions"></span>
                             </a>
                         </li>
                         <li class="active">
@@ -96,7 +109,7 @@
                                     <polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline>
                                     <line x1="12" y1="22.08" x2="12" y2="12"></line>
                                 </svg>
-                                <span class="ml-4">Go Routines Stats</span>
+                                <span class="ml-4">Go Routines Stats</span><span class="mg-badge" id="mg-count-goroutines"></span>
                             </a>
                         </li>
                         <li class=" ">
@@ -117,6 +130,13 @@
                         </li>
                     </ul>
                 </nav>
+                <div class="mg-storage">
+                    <div class="mg-storage-head">
+                        <span>STORAGE</span>
+                        <span id="mg-storage-mode">&nbsp;</span>
+                    </div>
+                    <div class="mg-storage-value" id="mg-storage-value">&nbsp;</div>
+                </div>
                 <div id="sidebar-bottom" class="position-relative sidebar-bottom">
                     <div class="card border-none border-radius-20 p-2 bg-success-light">
                         <div class="card-body">

--- a/static/index.html
+++ b/static/index.html
@@ -53,9 +53,22 @@
                     <svg class="icon wrapper-menu" aria-hidden="true"><use href="#i-menu"></use></svg>
                 </div>
             </div>
+            <!-- Service identity. The design puts what you are looking at above
+                 the navigation, so the page answers "which service is this?"
+                 without a round trip. Populated by common.js. -->
+            <div class="mg-identity">
+                <div class="mg-identity-avatar" id="mg-avatar">--</div>
+                <div class="mg-identity-text">
+                    <span class="mg-identity-name" id="mg-service-name">&nbsp;</span>
+                    <span class="mg-identity-meta" id="mg-service-meta">&nbsp;</span>
+                </div>
+                <span class="mg-identity-dot" id="mg-status-dot" title="Connected"></span>
+            </div>
+
             <div class="data-scrollbar" data-scroll="1">
                 <nav class="iq-sidebar-menu">
                     <ul id="iq-sidebar-toggle" class="iq-menu">
+                        <li class="mg-navlabel">MONITOR</li>
                         <li class="active">
                             <a href="./index.html" class="svg-icon">
                                 <svg class="svg-icon" id="p-dash1" width="20" height="20"
@@ -83,7 +96,7 @@
                                     <polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline>
                                     <line x1="12" y1="22.08" x2="12" y2="12"></line>
                                 </svg>
-                                <span class="ml-4">Function Metrics</span>
+                                <span class="ml-4">Function Metrics</span><span class="mg-badge" id="mg-count-functions"></span>
                             </a>
                         </li>
                         <li class=" ">
@@ -98,7 +111,7 @@
                                     <polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline>
                                     <line x1="12" y1="22.08" x2="12" y2="12"></line>
                                 </svg>
-                                <span class="ml-4">Go Routines Stats</span>
+                                <span class="ml-4">Go Routines Stats</span><span class="mg-badge" id="mg-count-goroutines"></span>
                             </a>
                         </li>
                         <li class=" ">
@@ -119,6 +132,13 @@
                         </li>
                     </ul>
                 </nav>
+                <div class="mg-storage">
+                    <div class="mg-storage-head">
+                        <span>STORAGE</span>
+                        <span id="mg-storage-mode">&nbsp;</span>
+                    </div>
+                    <div class="mg-storage-value" id="mg-storage-value">&nbsp;</div>
+                </div>
                 <div id="sidebar-bottom" class="position-relative sidebar-bottom">
                     <div class="card border-none border-radius-20 p-2 bg-success-light">
                         <div class="card-body">

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -148,6 +148,102 @@ document.addEventListener('DOMContentLoaded', () => {
             });
     }
 
+    // --- Shell: service identity, nav badges, storage footer ---------------
+    //
+    // These live in the sidebar chrome because they are true of the whole
+    // instrument rather than of any one page, so every page shows them and no
+    // page has to fetch them twice.
+
+    function setStatus(state) {
+        const dot = document.getElementById('mg-status-dot');
+        if (!dot) {
+            return;
+        }
+        dot.classList.remove('is-stale', 'is-down');
+        if (state !== 'ok') {
+            dot.classList.add(state === 'down' ? 'is-down' : 'is-stale');
+        }
+        dot.title = state === 'ok' ? 'Connected'
+            : state === 'down' ? 'Lost connection to the service'
+            : 'Data is stale';
+    }
+
+    function fillShell() {
+        authenticatedFetch('/monigo/api/v1/service-info')
+            .then(r => {
+                if (!r.ok) {
+                    throw new Error('HTTP ' + r.status);
+                }
+                return r.json();
+            })
+            .then(info => {
+                const name = info.service_name || 'service';
+                const nameEl = document.getElementById('mg-service-name');
+                const metaEl = document.getElementById('mg-service-meta');
+                const avatar = document.getElementById('mg-avatar');
+                if (nameEl) {
+                    nameEl.textContent = name;
+                    nameEl.title = name;
+                }
+                if (avatar) {
+                    avatar.textContent = name.slice(0, 2);
+                }
+                if (metaEl) {
+                    // The design's `pid 94917 · go1.21`: the two facts you need
+                    // to be sure you are looking at the right process.
+                    const go = (info.go_version || '').replace(/^go/, '');
+                    metaEl.textContent = `pid ${info.process_id || '-'}${go ? ' \u00b7 go' + go : ''}`;
+                }
+                // Retention and footprint are properties of the instrument, so
+                // they sit in the chrome. Both are omitted by the API when
+                // unset, so absent means "not configured", not "zero".
+                const mode = document.getElementById('mg-storage-mode');
+                const store = document.getElementById('mg-storage-value');
+                if (mode) {
+                    const parts = [info.storage_type, info.retention_period].filter(Boolean);
+                    mode.textContent = parts.join(' \u00b7 ');
+                }
+                if (store) {
+                    store.textContent = info.storage_on_disk
+                        ? `${info.storage_on_disk} retained`
+                        : (info.storage_type === 'memory' ? 'in memory' : '');
+                }
+                setStatus('ok');
+            })
+            .catch(() => setStatus('down'));
+    }
+
+    function fillNavBadges() {
+        authenticatedFetch('/monigo/api/v1/metrics')
+            .then(r => r.json())
+            .then(data => {
+                const g = document.getElementById('mg-count-goroutines');
+                if (g && data.core_statistics) {
+                    g.textContent = data.core_statistics.goroutines;
+                }
+
+                // Traced-function count. The endpoint returns a map keyed by
+                // function name, so its size is the count. Left blank when
+                // nothing is traced yet -- an empty badge is hidden by CSS
+                // rather than showing a zero that reads like a measurement.
+                authenticatedFetch('/monigo/api/v1/function')
+                    .then(r => r.json())
+                    .then(fns => {
+                        const el = document.getElementById('mg-count-functions');
+                        const n = fns && typeof fns === 'object' ? Object.keys(fns).length : 0;
+                        if (el) {
+                            el.textContent = n > 0 ? String(n) : '';
+                        }
+                    })
+                    .catch(() => { /* badge simply stays empty */ });
+                // storage footer is filled from /service-info, not here
+            })
+            .catch(() => { /* the status dot already carries the failure */ });
+    }
+
+    fillShell();
+    fillNavBadges();
+
     // Fetch metrics on load
     fetchMetrics();
 });

--- a/static/reports.html
+++ b/static/reports.html
@@ -52,9 +52,22 @@
                     <svg class="icon wrapper-menu" aria-hidden="true"><use href="#i-menu"></use></svg>
                 </div>
             </div>
+            <!-- Service identity. The design puts what you are looking at above
+                 the navigation, so the page answers "which service is this?"
+                 without a round trip. Populated by common.js. -->
+            <div class="mg-identity">
+                <div class="mg-identity-avatar" id="mg-avatar">--</div>
+                <div class="mg-identity-text">
+                    <span class="mg-identity-name" id="mg-service-name">&nbsp;</span>
+                    <span class="mg-identity-meta" id="mg-service-meta">&nbsp;</span>
+                </div>
+                <span class="mg-identity-dot" id="mg-status-dot" title="Connected"></span>
+            </div>
+
             <div class="data-scrollbar" data-scroll="1">
                 <nav class="iq-sidebar-menu">
                     <ul id="iq-sidebar-toggle" class="iq-menu">
+                        <li class="mg-navlabel">MONITOR</li>
                         <li class=" ">
                             <a href="./index.html" class="svg-icon">
                                 <svg class="svg-icon" id="p-dash1" width="20" height="20"
@@ -80,7 +93,7 @@
                                     <polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline>
                                     <line x1="12" y1="22.08" x2="12" y2="12"></line>
                                 </svg>
-                                <span class="ml-4">Function Metrics</span>
+                                <span class="ml-4">Function Metrics</span><span class="mg-badge" id="mg-count-functions"></span>
                             </a>
                         </li>
                         <li class=" ">
@@ -95,7 +108,7 @@
                                     <polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline>
                                     <line x1="12" y1="22.08" x2="12" y2="12"></line>
                                 </svg>
-                                <span class="ml-4">Go Routines Stats</span>
+                                <span class="ml-4">Go Routines Stats</span><span class="mg-badge" id="mg-count-goroutines"></span>
                             </a>
                         </li>
                         <li class="active">
@@ -117,6 +130,13 @@
                         </li>
                     </ul>
                 </nav>
+                <div class="mg-storage">
+                    <div class="mg-storage-head">
+                        <span>STORAGE</span>
+                        <span id="mg-storage-mode">&nbsp;</span>
+                    </div>
+                    <div class="mg-storage-value" id="mg-storage-value">&nbsp;</div>
+                </div>
                 <div id="sidebar-bottom" class="position-relative sidebar-bottom">
                     <div class="card border-none border-radius-20 p-2 bg-success-light">
                         <div class="card-body">

--- a/timeseries/monigodb.go
+++ b/timeseries/monigodb.go
@@ -137,6 +137,11 @@ func SetStorageType(t string) {
 	storageType = t
 }
 
+// GetStorageType returns the configured storage backend, "disk" or "memory".
+func GetStorageType() string {
+	return storageType
+}
+
 // GetStorageInstance initializes and returns a Storage instance.
 func GetStorageInstance() (Storage, error) {
 	manager.mu.Lock()


### PR DESCRIPTION
First half of **D3** from [DESIGN-ADOPTION.md](https://github.com/iyashjayesh/monigo/blob/main/DESIGN-ADOPTION.md). Refs #32.

The palette (#61) and type (#62) landed, but the *structure* was still the vendored template's — so the dashboard read as "the old dashboard, recoloured". This is the first change that alters what is on the page rather than how it looks.

## What the sidebar gains

Three things the design has and the template didn't:

- **Service identity above the navigation** — avatar, name, `pid 92366 · go1.25.1`, and a status dot that goes amber on stale data and crimson on a failed poll. A page now answers "which service is this?" without a round trip.
- **A `MONITOR` section label**, with live counts on the items that have a number worth showing — traced functions and goroutines.
- **A storage footer** — backend, retention window, on-disk footprint.

All three are chrome, true of the instrument rather than of any one page, so they live in the shell and every page gets them from a single fetch.

## API addition

The storage footer needed support: retention and footprint were known internally but never exposed. `/service-info` now carries `retention_period`, `storage_type` and `storage_on_disk`.

`storage_on_disk` is **omitted for the in-memory backend** rather than reported as `0 B` — "not applicable" and "nothing stored" are different statements, and a monitoring tool shouldn't conflate them. There's a test asserting exactly that.

## The template's hooks are untouched

`.iq-sidebar`, `.iq-sidebar-logo`, `.data-scrollbar`, `#iq-sidebar-toggle` and `.wrapper-menu` all still work, so the mobile toggle and scroll behaviour survive. The new markup is inserted *around* them rather than replacing them — which is why this is a ~200-line diff rather than a rewrite of four pages.

## Two things caught while building it

**Making the nav link a flex row collapsed the goroutines icon to 1px.** An `<svg>` with no intrinsic width has no flex basis to fall back on. The other three icons happened to survive because they carry `width` attributes. Fixed with an explicit basis on the icon.

**`margin-left: auto` on the count badge didn't apply** — the vendored rules override it. Rather than reach for another `!important`, the label grows into the slack, which pushes the badge right on its own.

## Verification

All four pages, both themes, no console errors:

```
identity     data-api · pid 92366 · go1.25.1 · connected
badges       Function Metrics 2   ·   Go Routines Stats 13
storage      disk · 4d  /  0.00 MB retained
icons        20px on all four items
```

A badge with no value is hidden rather than showing a zero that reads like a measurement.

```
go vet ./...                    clean
go test ./... -race -count=1    all 11 packages pass
node --check                    all non-vendored dashboard JS parses
```

## Not in this PR

The Overview page's own layout — sparkline metric tiles, the `SYSTEM HEALTH` threshold bars, the time-range selector and LIVE indicator. That's the second half of D3, and it rebuilds the metric grid rather than adding to the chrome, so it wants its own review.
