### PR TITLE
fix(security): stop the dashboard asserting its own privilege

### DIFF
--- a/static/js/common.js
+++ b/static/js/common.js
@@ -14,47 +14,29 @@ document.addEventListener('DOMContentLoaded', () => {
         return urlParams.get('api_key');
     }
 
-    // Function to add API key to fetch URL (only for API key auth)
-    function addApiKeyToUrl(url) {
-        const apiKey = getApiKey();
-        if (apiKey) {
-            const separator = url.includes('?') ? '&' : '?';
-            return `${url}${separator}api_key=${encodeURIComponent(apiKey)}`;
-        }
-        return url;
-    }
-
     // Function to make authenticated fetch request
     function authenticatedFetch(url, options = {}) {
         const apiKey = getApiKey();
         if (apiKey) {
-            // API key authentication - add to URL
-            const separator = url.includes('?') ? '&' : '?';
-            url = `${url}${separator}api_key=${encodeURIComponent(apiKey)}`;
-        } else {
-            // Check for custom authentication methods
-            const urlParams = new URLSearchParams(window.location.search);
-            const secret = urlParams.get('secret');
-
-            if (secret === 'monigo-admin-secret') {
-                // Custom query parameter authentication
-                const separator = url.includes('?') ? '&' : '?';
-                url = `${url}${separator}secret=${encodeURIComponent(secret)}`;
-            } else {
-                // Check for custom header authentication
-                // For custom auth, we need to add headers
-                if (!options.headers) {
-                    options.headers = {};
-                }
-
-                // Add custom header for admin access
-                options.headers['X-User-Role'] = 'admin';
-
-                // Set custom user agent for automated access
-                options.headers['User-Agent'] = 'MoniGo-Admin/1.0';
-            }
+            /*
+             * The key goes in a header, never the URL. As a query parameter it
+             * lands in browser history, in the Referer sent to any external
+             * link, and in every access log between here and the process.
+             * APIKeyMiddleware accepts either form, so the header suffices.
+             */
+            options.headers = Object.assign({}, options.headers, { 'X-API-Key': apiKey });
         }
-        // For basic auth, the browser handles credentials automatically
+        /*
+         * No other credential is attached. This used to assert a privileged
+         * role header on every unauthenticated request, copied from
+         * example/security-examples/custom-auth -- whose auth function grants
+         * access for exactly that header. The dashboard could therefore satisfy
+         * a consumer's own auth check on its own say-so. A browser cannot be
+         * trusted to assert its own privilege level, so it no longer claims
+         * one; custom auth belongs in the middleware, not in page JavaScript.
+         *
+         * Basic auth needs nothing here -- the browser attaches credentials.
+         */
         return fetch(url, options);
     }
 

--- a/static/js/functionTrace.js
+++ b/static/js/functionTrace.js
@@ -6,47 +6,29 @@ document.addEventListener('DOMContentLoaded', () => {
             return urlParams.get('api_key');
         }
 
-        // Function to add API key to fetch URL (only for API key auth)
-        function addApiKeyToUrl(url) {
-            const apiKey = getApiKey();
-            if (apiKey) {
-                const separator = url.includes('?') ? '&' : '?';
-                return `${url}${separator}api_key=${encodeURIComponent(apiKey)}`;
-            }
-            return url;
-        }
-
         // Function to make authenticated fetch request
         function authenticatedFetch(url, options = {}) {
             const apiKey = getApiKey();
             if (apiKey) {
-                // API key authentication - add to URL
-                const separator = url.includes('?') ? '&' : '?';
-                url = `${url}${separator}api_key=${encodeURIComponent(apiKey)}`;
-            } else {
-                // Check for custom authentication methods
-                const urlParams = new URLSearchParams(window.location.search);
-                const secret = urlParams.get('secret');
-
-                if (secret === 'monigo-admin-secret') {
-                    // Custom query parameter authentication
-                    const separator = url.includes('?') ? '&' : '?';
-                    url = `${url}${separator}secret=${encodeURIComponent(secret)}`;
-                } else {
-                    // Check for custom header authentication
-                    // For custom auth, we need to add headers
-                    if (!options.headers) {
-                        options.headers = {};
-                    }
-
-                    // Add custom header for admin access
-                    options.headers['X-User-Role'] = 'admin';
-
-                    // Set custom user agent for automated access
-                    options.headers['User-Agent'] = 'MoniGo-Admin/1.0';
-                }
+                /*
+                 * The key goes in a header, never the URL. As a query parameter it
+                 * lands in browser history, in the Referer sent to any external
+                 * link, and in every access log between here and the process.
+                 * APIKeyMiddleware accepts either form, so the header suffices.
+                 */
+                options.headers = Object.assign({}, options.headers, { 'X-API-Key': apiKey });
             }
-            // For basic auth, the browser handles credentials automatically
+            /*
+             * No other credential is attached. This used to assert a privileged
+             * role header on every unauthenticated request, copied from
+             * example/security-examples/custom-auth -- whose auth function grants
+             * access for exactly that header. The dashboard could therefore satisfy
+             * a consumer's own auth check on its own say-so. A browser cannot be
+             * trusted to assert its own privilege level, so it no longer claims
+             * one; custom auth belongs in the middleware, not in page JavaScript.
+             *
+             * Basic auth needs nothing here -- the browser attaches credentials.
+             */
             return fetch(url, options);
         }
 

--- a/static/js/goroutines.js
+++ b/static/js/goroutines.js
@@ -5,47 +5,29 @@ document.addEventListener('DOMContentLoaded', () => {
         return urlParams.get('api_key');
     }
 
-    // Function to add API key to fetch URL (only for API key auth)
-    function addApiKeyToUrl(url) {
-        const apiKey = getApiKey();
-        if (apiKey) {
-            const separator = url.includes('?') ? '&' : '?';
-            return `${url}${separator}api_key=${encodeURIComponent(apiKey)}`;
-        }
-        return url;
-    }
-
     // Function to make authenticated fetch request
     function authenticatedFetch(url, options = {}) {
         const apiKey = getApiKey();
         if (apiKey) {
-            // API key authentication - add to URL
-            const separator = url.includes('?') ? '&' : '?';
-            url = `${url}${separator}api_key=${encodeURIComponent(apiKey)}`;
-        } else {
-            // Check for custom authentication methods
-            const urlParams = new URLSearchParams(window.location.search);
-            const secret = urlParams.get('secret');
-
-            if (secret === 'monigo-admin-secret') {
-                // Custom query parameter authentication
-                const separator = url.includes('?') ? '&' : '?';
-                url = `${url}${separator}secret=${encodeURIComponent(secret)}`;
-            } else {
-                // Check for custom header authentication
-                // For custom auth, we need to add headers
-                if (!options.headers) {
-                    options.headers = {};
-                }
-
-                // Add custom header for admin access
-                options.headers['X-User-Role'] = 'admin';
-
-                // Set custom user agent for automated access
-                options.headers['User-Agent'] = 'MoniGo-Admin/1.0';
-            }
+            /*
+             * The key goes in a header, never the URL. As a query parameter it
+             * lands in browser history, in the Referer sent to any external
+             * link, and in every access log between here and the process.
+             * APIKeyMiddleware accepts either form, so the header suffices.
+             */
+            options.headers = Object.assign({}, options.headers, { 'X-API-Key': apiKey });
         }
-        // For basic auth, the browser handles credentials automatically
+        /*
+         * No other credential is attached. This used to assert a privileged
+         * role header on every unauthenticated request, copied from
+         * example/security-examples/custom-auth -- whose auth function grants
+         * access for exactly that header. The dashboard could therefore satisfy
+         * a consumer's own auth check on its own say-so. A browser cannot be
+         * trusted to assert its own privilege level, so it no longer claims
+         * one; custom auth belongs in the middleware, not in page JavaScript.
+         *
+         * Basic auth needs nothing here -- the browser attaches credentials.
+         */
         return fetch(url, options);
     }
 

--- a/static/js/historycharts.js
+++ b/static/js/historycharts.js
@@ -5,47 +5,29 @@ document.addEventListener('DOMContentLoaded', () => {
         return urlParams.get('api_key');
     }
 
-    // Function to add API key to fetch URL (only for API key auth)
-    function addApiKeyToUrl(url) {
-        const apiKey = getApiKey();
-        if (apiKey) {
-            const separator = url.includes('?') ? '&' : '?';
-            return `${url}${separator}api_key=${encodeURIComponent(apiKey)}`;
-        }
-        return url;
-    }
-
     // Function to make authenticated fetch request
     function authenticatedFetch(url, options = {}) {
         const apiKey = getApiKey();
         if (apiKey) {
-            // API key authentication - add to URL
-            const separator = url.includes('?') ? '&' : '?';
-            url = `${url}${separator}api_key=${encodeURIComponent(apiKey)}`;
-        } else {
-            // Check for custom authentication methods
-            const urlParams = new URLSearchParams(window.location.search);
-            const secret = urlParams.get('secret');
-
-            if (secret === 'monigo-admin-secret') {
-                // Custom query parameter authentication
-                const separator = url.includes('?') ? '&' : '?';
-                url = `${url}${separator}secret=${encodeURIComponent(secret)}`;
-            } else {
-                // Check for custom header authentication
-                // For custom auth, we need to add headers
-                if (!options.headers) {
-                    options.headers = {};
-                }
-
-                // Add custom header for admin access
-                options.headers['X-User-Role'] = 'admin';
-
-                // Set custom user agent for automated access
-                options.headers['User-Agent'] = 'MoniGo-Admin/1.0';
-            }
+            /*
+             * The key goes in a header, never the URL. As a query parameter it
+             * lands in browser history, in the Referer sent to any external
+             * link, and in every access log between here and the process.
+             * APIKeyMiddleware accepts either form, so the header suffices.
+             */
+            options.headers = Object.assign({}, options.headers, { 'X-API-Key': apiKey });
         }
-        // For basic auth, the browser handles credentials automatically
+        /*
+         * No other credential is attached. This used to assert a privileged
+         * role header on every unauthenticated request, copied from
+         * example/security-examples/custom-auth -- whose auth function grants
+         * access for exactly that header. The dashboard could therefore satisfy
+         * a consumer's own auth check on its own say-so. A browser cannot be
+         * trusted to assert its own privilege level, so it no longer claims
+         * one; custom auth belongs in the middleware, not in page JavaScript.
+         *
+         * Basic auth needs nothing here -- the browser attaches credentials.
+         */
         return fetch(url, options);
     }
 

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -5,47 +5,29 @@ document.addEventListener('DOMContentLoaded', () => {
         return urlParams.get('api_key');
     }
 
-    // Function to add API key to fetch URL (only for API key auth)
-    function addApiKeyToUrl(url) {
-        const apiKey = getApiKey();
-        if (apiKey) {
-            const separator = url.includes('?') ? '&' : '?';
-            return `${url}${separator}api_key=${encodeURIComponent(apiKey)}`;
-        }
-        return url;
-    }
-
     // Function to make authenticated fetch request
     function authenticatedFetch(url, options = {}) {
         const apiKey = getApiKey();
         if (apiKey) {
-            // API key authentication - add to URL
-            const separator = url.includes('?') ? '&' : '?';
-            url = `${url}${separator}api_key=${encodeURIComponent(apiKey)}`;
-        } else {
-            // Check for custom authentication methods
-            const urlParams = new URLSearchParams(window.location.search);
-            const secret = urlParams.get('secret');
-
-            if (secret === 'monigo-admin-secret') {
-                // Custom query parameter authentication
-                const separator = url.includes('?') ? '&' : '?';
-                url = `${url}${separator}secret=${encodeURIComponent(secret)}`;
-            } else {
-                // Check for custom header authentication
-                // For custom auth, we need to add headers
-                if (!options.headers) {
-                    options.headers = {};
-                }
-
-                // Add custom header for admin access
-                options.headers['X-User-Role'] = 'admin';
-
-                // Set custom user agent for automated access
-                options.headers['User-Agent'] = 'MoniGo-Admin/1.0';
-            }
+            /*
+             * The key goes in a header, never the URL. As a query parameter it
+             * lands in browser history, in the Referer sent to any external
+             * link, and in every access log between here and the process.
+             * APIKeyMiddleware accepts either form, so the header suffices.
+             */
+            options.headers = Object.assign({}, options.headers, { 'X-API-Key': apiKey });
         }
-        // For basic auth, the browser handles credentials automatically
+        /*
+         * No other credential is attached. This used to assert a privileged
+         * role header on every unauthenticated request, copied from
+         * example/security-examples/custom-auth -- whose auth function grants
+         * access for exactly that header. The dashboard could therefore satisfy
+         * a consumer's own auth check on its own say-so. A browser cannot be
+         * trusted to assert its own privilege level, so it no longer claims
+         * one; custom auth belongs in the middleware, not in page JavaScript.
+         *
+         * Basic auth needs nothing here -- the browser attaches credentials.
+         */
         return fetch(url, options);
     }
 

--- a/static/js/reports.js
+++ b/static/js/reports.js
@@ -5,47 +5,29 @@ document.addEventListener('DOMContentLoaded', () => {
         return urlParams.get('api_key');
     }
 
-    // Function to add API key to fetch URL (only for API key auth)
-    function addApiKeyToUrl(url) {
-        const apiKey = getApiKey();
-        if (apiKey) {
-            const separator = url.includes('?') ? '&' : '?';
-            return `${url}${separator}api_key=${encodeURIComponent(apiKey)}`;
-        }
-        return url;
-    }
-
     // Function to make authenticated fetch request
     function authenticatedFetch(url, options = {}) {
         const apiKey = getApiKey();
         if (apiKey) {
-            // API key authentication - add to URL
-            const separator = url.includes('?') ? '&' : '?';
-            url = `${url}${separator}api_key=${encodeURIComponent(apiKey)}`;
-        } else {
-            // Check for custom authentication methods
-            const urlParams = new URLSearchParams(window.location.search);
-            const secret = urlParams.get('secret');
-
-            if (secret === 'monigo-admin-secret') {
-                // Custom query parameter authentication
-                const separator = url.includes('?') ? '&' : '?';
-                url = `${url}${separator}secret=${encodeURIComponent(secret)}`;
-            } else {
-                // Check for custom header authentication
-                // For custom auth, we need to add headers
-                if (!options.headers) {
-                    options.headers = {};
-                }
-
-                // Add custom header for admin access
-                options.headers['X-User-Role'] = 'admin';
-
-                // Set custom user agent for automated access
-                options.headers['User-Agent'] = 'MoniGo-Admin/1.0';
-            }
+            /*
+             * The key goes in a header, never the URL. As a query parameter it
+             * lands in browser history, in the Referer sent to any external
+             * link, and in every access log between here and the process.
+             * APIKeyMiddleware accepts either form, so the header suffices.
+             */
+            options.headers = Object.assign({}, options.headers, { 'X-API-Key': apiKey });
         }
-        // For basic auth, the browser handles credentials automatically
+        /*
+         * No other credential is attached. This used to assert a privileged
+         * role header on every unauthenticated request, copied from
+         * example/security-examples/custom-auth -- whose auth function grants
+         * access for exactly that header. The dashboard could therefore satisfy
+         * a consumer's own auth check on its own say-so. A browser cannot be
+         * trusted to assert its own privilege level, so it no longer claims
+         * one; custom auth belongs in the middleware, not in page JavaScript.
+         *
+         * Basic auth needs nothing here -- the browser attaches credentials.
+         */
         return fetch(url, options);
     }
 

--- a/static_assets_test.go
+++ b/static_assets_test.go
@@ -1,6 +1,7 @@
 package monigo
 
 import (
+	"bytes"
 	"fmt"
 	"io/fs"
 	"net/url"
@@ -355,5 +356,92 @@ func TestEmbeddedPayloadHasNoJunkFiles(t *testing.T) {
 		sort.Strings(found)
 		t.Errorf("junk files embedded into the binary:\n  %s\n\nDelete them and add the pattern to .gitignore.",
 			strings.Join(found, "\n  "))
+	}
+}
+
+// The dashboard is a browser page. It cannot be trusted to assert its own
+// privilege level, because anything it sends, any visitor can send.
+//
+// It previously did exactly that: authenticatedFetch attached a privileged
+// role header and a hardcoded shared secret to every request that carried no
+// API key, both copied from example/security-examples/custom-auth -- whose
+// auth function grants access for precisely those two credentials. A consumer
+// following that documented example got a dashboard that satisfied their own
+// auth check on its own say-so.
+//
+// The same block was copy-pasted into all six page scripts, so this checks
+// every embedded file rather than the one it was noticed in.
+func TestDashboardAssertsNoPrivilegeOfItsOwn(t *testing.T) {
+	banned := map[string]string{
+		"X-User-Role":         "a self-asserted role header",
+		"monigo-admin-secret": "a hardcoded shared secret from the custom-auth example",
+		"MoniGo-Admin":        "a spoofed User-Agent used as a credential",
+	}
+
+	err := fs.WalkDir(staticFiles, "static", func(p string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		if !strings.HasSuffix(p, ".js") && !strings.HasSuffix(p, ".html") {
+			return nil
+		}
+		// Vendored template code is not ours and never had this.
+		if strings.Contains(p, "/core/") {
+			return nil
+		}
+		body, err := staticFiles.ReadFile(p)
+		if err != nil {
+			return err
+		}
+		for needle, what := range banned {
+			if bytes.Contains(body, []byte(needle)) {
+				t.Errorf("%s contains %q -- %s.\n"+
+					"The dashboard must not send a credential that grants it access; "+
+					"custom authentication belongs in the middleware, not in page "+
+					"JavaScript, because a browser cannot vouch for itself.",
+					p, needle, what)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking embedded files: %v", err)
+	}
+}
+
+// An API key in a query string is recorded in browser history, sent in the
+// Referer header to any external link the page carries, and written to every
+// access log between the browser and the process. APIKeyMiddleware accepts an
+// X-API-Key header too (monigo.go), so the header costs nothing and leaks
+// nothing.
+func TestDashboardSendsTheAPIKeyAsAHeaderNotAQueryParameter(t *testing.T) {
+	// Matches building a URL with the key appended, which is how it used to be
+	// done: `${url}${separator}api_key=${...}`.
+	urlBuild := regexp.MustCompile(`api_key=\$\{|[?&]api_key=`)
+
+	err := fs.WalkDir(staticFiles, "static", func(p string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(p, ".js") {
+			return err
+		}
+		if strings.Contains(p, "/core/") {
+			return nil
+		}
+		body, err := staticFiles.ReadFile(p)
+		if err != nil {
+			return err
+		}
+		if urlBuild.Match(body) {
+			t.Errorf("%s builds a URL containing api_key. Send it as an X-API-Key "+
+				"header instead: a query parameter lands in browser history, in the "+
+				"Referer sent to external links, and in access logs.", p)
+		}
+		// Reading the key from the page's own URL is how it arrives and is fine.
+		if !bytes.Contains(body, []byte("X-API-Key")) && bytes.Contains(body, []byte("getApiKey")) {
+			t.Errorf("%s reads an API key but never sends an X-API-Key header", p)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking embedded scripts: %v", err)
 	}
 }


### PR DESCRIPTION
## The problem

`authenticatedFetch` — copy-pasted into all six page scripts — attached two credentials to every request that carried no API key:

```js
options.headers['X-User-Role'] = 'admin';
options.headers['User-Agent']  = 'MoniGo-Admin/1.0';
```

and, failing that, appended `secret=monigo-admin-secret` to the URL.

Both values come from [`example/security-examples/custom-auth`](example/security-examples/custom-auth/custom-auth-example.go#L64), whose `customAuthFunction` returns `true` for precisely them. **A consumer who followed that documented example got a dashboard that satisfied their own auth check on its own say-so** — the page asserted the privilege it was supposed to be granted.

A browser cannot vouch for itself: anything the dashboard sends, any visitor to it can send. Custom authentication belongs in the middleware, where the server decides.

The `User-Agent` line was inert — it is a [forbidden header name](https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name) that browsers refuse to set from `fetch` — but it went with the rest.

## Also: the API key was in the URL

As a query parameter the key is recorded in browser history, sent in the `Referer` to any external link the page carries, and written to every access log between the browser and the process. It now goes in an `X-API-Key` header. `APIKeyMiddleware` (`monigo.go:782`) already accepts either form, so the header costs nothing.

`addApiKeyToUrl` is deleted rather than left dead — its whole purpose was to put the key somewhere it should not go.

## Guardrails

Two regression tests, each **confirmed failing against the previous code** and passing against this one:

- `TestDashboardAssertsNoPrivilegeOfItsOwn` — no embedded script or page may contain a self-asserted role header, the hardcoded secret, or the spoofed user-agent.
- `TestDashboardSendsTheAPIKeyAsAHeaderNotAQueryParameter` — no script may build a URL containing `api_key`, and any script that reads a key must send it as a header.

## Verification

Against a server running `APIKeyMiddleware`:

| request | result |
| --- | --- |
| no credential | 401 |
| `X-API-Key` header | 200 |
| `?api_key=` query | 200 |
| wrong key | 401 |
| **`X-User-Role: admin` alone** | **401** |
| static asset, no key | 200 |

In the browser: the dashboard loads, renders real data, and **every** API call returns 200 with **no `api_key` in any URL** — so the key is arriving in the header. Console clean. Full suite green.

## Scope

Front-end only — six `static/js/*.js` files and the test file. No Go behaviour changes, no API changes. Independent of the dashboard redesign and safe to release on its own.
