### PR TITLE
feat(metrics): call counts and approximate latency percentiles (#68)

### DIFF
--- a/core/function-metrics.go
+++ b/core/function-metrics.go
@@ -219,13 +219,22 @@ func executeFunctionWithProfiling(name string, fn func()) {
 		var err error
 		cpuProfileFile, err = StartCPUProfile(cpuProfFilePath)
 		if err != nil {
+			// Usually "already in use": another traced call is being sampled,
+			// and profiling is process-wide. Clearing the path keeps this call
+			// honest about having no profile rather than pointing at a file
+			// that is empty or belongs to the other call.
 			logger.Log.Warn("failed to start CPU profile", "error", err)
+			cpuProfFilePath = ""
 		}
 	}
 
 	start := time.Now()
 	fn()
 	elapsed := time.Since(start)
+
+	// Every call, not just profiled ones: timing is cheap and the distribution
+	// is only meaningful if it covers everything.
+	observeLatency(name, elapsed)
 
 	if shouldProfile {
 		StopCPUProfile(cpuProfileFile)
@@ -272,9 +281,15 @@ func executeFunctionWithProfiling(name string, fn func()) {
 		}
 	}
 
+	p50, p95, _, reliable := latencySummary(name)
+
 	if m, exists := functionMetrics[name]; exists {
 		m.FunctionLastRanAt = start
 		m.ExecutionTime = elapsed
+		m.CallCount = count
+		m.ApproximateP50 = p50
+		m.ApproximateP95 = p95
+		m.PercentilesReliable = reliable
 		m.GoroutineCount = goroutineDelta
 		if shouldProfile {
 			m.MemoryUsage = memoryUsage
@@ -284,13 +299,17 @@ func executeFunctionWithProfiling(name string, fn func()) {
 		}
 	} else {
 		functionMetrics[name] = &models.FunctionMetrics{
-			FunctionLastRanAt:  start,
-			ExecutionTime:      elapsed,
-			GoroutineCount:     goroutineDelta,
-			MemoryUsage:        memoryUsage,
-			MemoryUsageSampled: shouldProfile,
-			CPUProfileFilePath: cpuProfFilePath,
-			MemProfileFilePath: memProfFilePath,
+			FunctionLastRanAt:   start,
+			ExecutionTime:       elapsed,
+			CallCount:           count,
+			ApproximateP50:      p50,
+			ApproximateP95:      p95,
+			PercentilesReliable: reliable,
+			GoroutineCount:      goroutineDelta,
+			MemoryUsage:         memoryUsage,
+			MemoryUsageSampled:  shouldProfile,
+			CPUProfileFilePath:  cpuProfFilePath,
+			MemProfileFilePath:  memProfFilePath,
 		}
 	}
 }

--- a/core/latency_histogram.go
+++ b/core/latency_histogram.go
@@ -1,0 +1,158 @@
+package core
+
+import (
+	"math"
+	"sync"
+	"time"
+)
+
+/*
+A bounded latency distribution per traced function.
+
+The dashboard wants p50 and p95, which need a distribution rather than the
+single last-call duration FunctionMetrics carries. Keeping the raw durations
+would give exact percentiles, but at maxTrackedFunctions (10 000) a ring of 128
+int64s per function is roughly 10 MB held permanently -- in a library whose
+whole argument is that it is cheap to embed, and which just cut its dashboard
+payload from 7.9 MB to 356 KB for that reason.
+
+So: fixed exponential buckets. Each function costs one fixed-size array of
+counters regardless of how often it is called, which puts the ceiling at roughly
+800 KB for the same 10 000 functions. Percentiles come back at bucket
+resolution, which is enough to answer "which function is slow" -- the question
+the column exists for -- and is not enough to quote as an SLO. Callers are told
+which, via ApproximateP50/P95 naming and the doc on the model fields.
+
+Timing is not sampled: executeFunctionWithProfiling measures every call, and
+only *profiling* runs at one call in samplingRate. So the distribution covers
+every call, not one percent of them.
+*/
+
+const (
+	// histogramBuckets spans 1µs to ~17s in powers of four, which brackets
+	// everything from a tight loop to a call that should have timed out.
+	// Powers of four rather than two keeps the array short at the cost of
+	// coarser resolution; at p95 the bucket edges matter less than the
+	// magnitude.
+	histogramBuckets = 13
+
+	// histogramBase is the upper bound of the first bucket.
+	histogramBase = time.Microsecond
+
+	// minSamplesForPercentile is the point below which a percentile stops
+	// being a summary and becomes an anecdote. p95 of three calls is just the
+	// slowest of three; reporting it as a percentile invites someone to read
+	// it as a stable property of the function.
+	minSamplesForPercentile = 20
+)
+
+// bucketUpperBounds[i] is the inclusive upper bound of bucket i. The final
+// bucket is unbounded.
+var bucketUpperBounds = func() [histogramBuckets]time.Duration {
+	var b [histogramBuckets]time.Duration
+	d := histogramBase
+	for i := 0; i < histogramBuckets; i++ {
+		b[i] = d
+		d *= 4
+	}
+	b[histogramBuckets-1] = time.Duration(math.MaxInt64)
+	return b
+}()
+
+type latencyHistogram struct {
+	counts [histogramBuckets]uint64
+	total  uint64
+}
+
+func (h *latencyHistogram) observe(d time.Duration) {
+	if d < 0 {
+		return
+	}
+	for i := 0; i < histogramBuckets; i++ {
+		if d <= bucketUpperBounds[i] {
+			h.counts[i]++
+			h.total++
+			return
+		}
+	}
+	// Unreachable: the last bound is MaxInt64. Kept so a future edit to the
+	// bounds cannot silently drop observations.
+	h.counts[histogramBuckets-1]++
+	h.total++
+}
+
+/*
+quantile returns the upper bound of the bucket in which the requested quantile
+falls, and whether there were enough samples for the answer to mean anything.
+
+The value is deliberately the bucket's upper bound rather than an interpolation
+across it: interpolating would produce a precise-looking number the data does
+not support. A caller that sees 4ms should read "at most 4ms", which is true,
+rather than "4.13ms", which is invented.
+*/
+func (h *latencyHistogram) quantile(q float64) (time.Duration, bool) {
+	if h.total < minSamplesForPercentile {
+		return 0, false
+	}
+	target := uint64(math.Ceil(q * float64(h.total)))
+	if target == 0 {
+		target = 1
+	}
+	var cumulative uint64
+	for i := 0; i < histogramBuckets; i++ {
+		cumulative += h.counts[i]
+		if cumulative >= target {
+			return bucketUpperBounds[i], true
+		}
+	}
+	return bucketUpperBounds[histogramBuckets-1], true
+}
+
+var (
+	latencyMu sync.Mutex
+	latencies = make(map[string]*latencyHistogram)
+)
+
+// observeLatency records one call duration for a function.
+func observeLatency(name string, d time.Duration) {
+	latencyMu.Lock()
+	defer latencyMu.Unlock()
+
+	h, ok := latencies[name]
+	if !ok {
+		// Bounded by the same cap as functionMetrics, and evicted the same way,
+		// so the two maps cannot drift into holding different function sets.
+		if len(latencies) >= maxTrackedFunctions {
+			for k := range latencies {
+				delete(latencies, k)
+				break
+			}
+		}
+		h = &latencyHistogram{}
+		latencies[name] = h
+	}
+	h.observe(d)
+}
+
+// latencySummary returns the approximate p50 and p95 for a function, and the
+// number of observations behind them. ok is false when there have been too few
+// calls for a percentile to be meaningful.
+func latencySummary(name string) (p50, p95 time.Duration, samples uint64, ok bool) {
+	latencyMu.Lock()
+	defer latencyMu.Unlock()
+
+	h, exists := latencies[name]
+	if !exists {
+		return 0, 0, 0, false
+	}
+	p50, ok50 := h.quantile(0.50)
+	p95, ok95 := h.quantile(0.95)
+	return p50, p95, h.total, ok50 && ok95
+}
+
+// resetLatencies clears the distributions. For tests.
+func resetLatencies() {
+	latencyMu.Lock()
+	defer latencyMu.Unlock()
+	latencies = make(map[string]*latencyHistogram)
+}

--- a/core/latency_histogram_test.go
+++ b/core/latency_histogram_test.go
@@ -1,0 +1,159 @@
+package core
+
+import (
+	"testing"
+	"time"
+)
+
+// A percentile over a handful of calls is not a percentile, it is the slowest
+// of a handful. Reporting one invites it to be read as a stable property of the
+// function, so below the floor the summary refuses to answer.
+func TestPercentilesRefuseToAnswerBelowTheSampleFloor(t *testing.T) {
+	t.Cleanup(resetLatencies)
+	resetLatencies()
+
+	for i := 0; i < minSamplesForPercentile-1; i++ {
+		observeLatency("few", 5*time.Millisecond)
+	}
+	if _, _, _, ok := latencySummary("few"); ok {
+		t.Errorf("summary reported as reliable with %d samples, floor is %d",
+			minSamplesForPercentile-1, minSamplesForPercentile)
+	}
+
+	observeLatency("few", 5*time.Millisecond) // now at the floor
+	p50, p95, n, ok := latencySummary("few")
+	if !ok {
+		t.Fatalf("summary still unreliable at the floor (%d samples)", n)
+	}
+	if p50 <= 0 || p95 <= 0 {
+		t.Errorf("p50=%v p95=%v, both should be positive once reliable", p50, p95)
+	}
+}
+
+// An unseen function has no distribution, which is different from one whose
+// calls were all instant.
+func TestUnknownFunctionHasNoSummary(t *testing.T) {
+	t.Cleanup(resetLatencies)
+	resetLatencies()
+	if _, _, n, ok := latencySummary("never-called"); ok || n != 0 {
+		t.Errorf("unknown function reported samples=%d ok=%v, want 0/false", n, ok)
+	}
+}
+
+// The quantile must land in the right region of the distribution: a run that is
+// overwhelmingly fast with a slow tail should put p50 near the fast bucket and
+// p95 out in the slow one.
+func TestQuantilesTrackTheDistribution(t *testing.T) {
+	t.Cleanup(resetLatencies)
+	resetLatencies()
+
+	// 90/10, not 95/5. With exactly 5% slow the 950th ordered value of 1000 is
+	// still the last fast one, so p95 lands on the fast bucket -- correct
+	// arithmetic, and a poor test of whether the tail is found at all.
+	for i := 0; i < 900; i++ {
+		observeLatency("skewed", 10*time.Microsecond)
+	}
+	for i := 0; i < 100; i++ {
+		observeLatency("skewed", 2*time.Second)
+	}
+
+	p50, p95, n, ok := latencySummary("skewed")
+	if !ok {
+		t.Fatalf("expected a reliable summary from %d samples", n)
+	}
+	if p50 > time.Millisecond {
+		t.Errorf("p50 = %v, want it down with the 90%% of 10µs calls", p50)
+	}
+	if p95 < 100*time.Millisecond {
+		t.Errorf("p95 = %v, want it out in the 2s tail", p95)
+	}
+	if p95 < p50 {
+		t.Errorf("p95 %v is below p50 %v", p95, p50)
+	}
+}
+
+// The returned value is a bucket upper bound, so the true duration is at or
+// below it. A quantile that under-reports would be the dangerous direction:
+// it would say a function is faster than it is.
+func TestQuantileIsAnUpperBoundNotAnUnderestimate(t *testing.T) {
+	t.Cleanup(resetLatencies)
+	resetLatencies()
+
+	const actual = 3 * time.Millisecond
+	for i := 0; i < 200; i++ {
+		observeLatency("steady", actual)
+	}
+	p50, p95, _, ok := latencySummary("steady")
+	if !ok {
+		t.Fatal("expected a reliable summary")
+	}
+	if p50 < actual || p95 < actual {
+		t.Errorf("p50=%v p95=%v below the observed %v; a percentile must never "+
+			"report a function as faster than it ran", p50, p95, actual)
+	}
+}
+
+// Memory is the whole reason for choosing buckets over raw samples, so the cost
+// per function must stay fixed however many calls it takes.
+func TestHistogramCostDoesNotGrowWithCallCount(t *testing.T) {
+	t.Cleanup(resetLatencies)
+	resetLatencies()
+
+	for i := 0; i < 100000; i++ {
+		observeLatency("hot", time.Duration(i%1000)*time.Microsecond)
+	}
+	latencyMu.Lock()
+	h := latencies["hot"]
+	latencyMu.Unlock()
+
+	if got := len(h.counts); got != histogramBuckets {
+		t.Errorf("bucket count = %d after 100k calls, want a fixed %d", got, histogramBuckets)
+	}
+	if h.total != 100000 {
+		t.Errorf("total = %d, want every call counted", h.total)
+	}
+}
+
+// The distribution map is capped like functionMetrics, so a process that traces
+// an unbounded number of distinct functions cannot grow without limit.
+func TestDistributionMapIsCapped(t *testing.T) {
+	t.Cleanup(resetLatencies)
+	resetLatencies()
+
+	for i := 0; i < maxTrackedFunctions+50; i++ {
+		observeLatency(string(rune(i%256))+"-"+time.Duration(i).String(), time.Millisecond)
+	}
+	latencyMu.Lock()
+	n := len(latencies)
+	latencyMu.Unlock()
+
+	if n > maxTrackedFunctions {
+		t.Errorf("tracking %d distributions, cap is %d", n, maxTrackedFunctions)
+	}
+}
+
+// The quantile convention matters and is easy to get backwards. With exactly 5%
+// of calls slow, the 95th percentile of 1000 samples is the 950th ordered
+// value, which is still a fast one -- the tail begins at 951. This pins that,
+// because the obvious-looking expectation is the wrong one and a future change
+// to the rounding would slip past without it.
+func TestP95SitsBelowATailOfExactlyFivePercent(t *testing.T) {
+	t.Cleanup(resetLatencies)
+	resetLatencies()
+
+	for i := 0; i < 950; i++ {
+		observeLatency("edge", 10*time.Microsecond)
+	}
+	for i := 0; i < 50; i++ {
+		observeLatency("edge", 2*time.Second)
+	}
+
+	_, p95, _, ok := latencySummary("edge")
+	if !ok {
+		t.Fatal("expected a reliable summary")
+	}
+	if p95 > time.Millisecond {
+		t.Errorf("p95 = %v; with exactly 5%% slow the 950th value is still fast, "+
+			"so p95 should not reach the tail", p95)
+	}
+}

--- a/core/profile.go
+++ b/core/profile.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"fmt"
 	"os"
 	"runtime"
 	"runtime/pprof"
@@ -11,12 +12,37 @@ import (
 )
 
 // StartCPUProfile starts the CPU profile and writes it to the specified file.
+/*
+StartCPUProfile begins a CPU profile into filename.
+
+The error from pprof.StartCPUProfile used to be discarded. CPU profiling is a
+process-wide singleton, so when two traced calls are sampled at once the second
+gets "cpu profiling already in use" -- and with the error dropped, this reported
+success, the caller recorded CPUProfileFilePath as though a profile existed, and
+what was actually on disk was the file os.Create had just truncated to zero
+bytes. The dashboard then offered a profile that was empty, or worse, showed one
+function's stacks under another function's name once the first call's
+StopCPUProfile wrote into it.
+
+On failure the truncated file is removed, so the caller can leave the path empty
+and the UI can say "not profiled" -- which is true -- instead of showing an
+empty graph.
+*/
 func StartCPUProfile(filename string) (*os.File, error) {
 	f, err := os.Create(filename)
 	if err != nil {
 		return nil, err
 	}
-	pprof.StartCPUProfile(f)
+	if err := pprof.StartCPUProfile(f); err != nil {
+		f.Close()
+		// Best-effort: the file is a zero-byte artefact of os.Create above and
+		// must not be left behind looking like a profile.
+		if rmErr := os.Remove(filename); rmErr != nil {
+			logger.Log.Warn("removing truncated profile file",
+				"file", filename, "error", rmErr)
+		}
+		return nil, fmt.Errorf("starting CPU profile: %w", err)
+	}
 	return f, nil
 }
 

--- a/core/profile_test.go
+++ b/core/profile_test.go
@@ -1,0 +1,39 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// CPU profiling is a process-wide singleton. When a second traced call tries to
+// start one while another is running, pprof refuses -- and that refusal used to
+// be discarded, so the caller recorded a profile path pointing at the zero-byte
+// file os.Create had just truncated.
+func TestConcurrentCPUProfileDoesNotLeaveATruncatedFile(t *testing.T) {
+	dir := t.TempDir()
+	first := filepath.Join(dir, "first.prof")
+	second := filepath.Join(dir, "second.prof")
+
+	f, err := StartCPUProfile(first)
+	if err != nil {
+		t.Fatalf("first profile should start: %v", err)
+	}
+	defer StopCPUProfile(f)
+
+	// Second one must be refused, not silently accepted.
+	f2, err := StartCPUProfile(second)
+	if err == nil {
+		StopCPUProfile(f2)
+		t.Fatal("second concurrent CPU profile reported success; pprof only " +
+			"supports one at a time, so this would have handed back a handle " +
+			"to a file the first profile is writing")
+	}
+	if f2 != nil {
+		t.Error("a failed start returned a non-nil file handle")
+	}
+	if _, statErr := os.Stat(second); !os.IsNotExist(statErr) {
+		t.Errorf("the truncated file was left on disk (%v); it looks like a "+
+			"profile to anything that finds it", statErr)
+	}
+}

--- a/models/apiModels.go
+++ b/models/apiModels.go
@@ -230,6 +230,26 @@ type FunctionMetrics struct {
 	MemoryUsage        uint64 `json:"memory_usage"`
 	MemoryUsageSampled bool   `json:"memory_usage_sampled"`
 
+	// CallCount is how many times this function has been traced. The counter
+	// already existed to drive sampling; it is reported because "how slow" is
+	// hard to read without "how often".
+	CallCount uint64 `json:"call_count"`
+
+	/*
+	 * ApproximateP50 and ApproximateP95 summarise call latency.
+	 *
+	 * Approximate is not a hedge: they come from a fixed-bucket histogram, so
+	 * each is the upper bound of the bucket the quantile falls in, not an
+	 * interpolated value. Read 4ms as "at most 4ms". Bucket resolution is
+	 * enough to find the slow function and not enough to quote as an SLO.
+	 *
+	 * Zero with PercentilesReliable false means too few calls to summarise --
+	 * p95 of three calls is just the slowest of three.
+	 */
+	ApproximateP50      time.Duration `json:"approximate_p50_ns"`
+	ApproximateP95      time.Duration `json:"approximate_p95_ns"`
+	PercentilesReliable bool          `json:"percentiles_reliable"`
+
 	// GoroutineCount is the change in the process-wide goroutine count observed
 	// across the last call: runtime.NumGoroutine() after minus before.
 	//

--- a/static/css/monigo-styles.css
+++ b/static/css/monigo-styles.css
@@ -732,13 +732,15 @@
 }
 
 .mg-fn-table {
-    min-width: 720px;
+    /* Eight columns need more room before the wrapper starts scrolling. */
+    min-width: 900px;
 }
 
 .mg-fn-thead,
 .mg-fn-row {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) 110px 110px 90px 110px;
+    /* name | calls | exec | p50 | p95 | mem | goro | last */
+    grid-template-columns: minmax(0, 1fr) 80px 100px 90px 90px 100px 80px 100px;
     gap: var(--s-4);
     align-items: center;
 }
@@ -810,6 +812,9 @@
 }
 
 .mg-fn-exec,
+.mg-fn-calls,
+.mg-fn-p50,
+.mg-fn-p95,
 .mg-fn-mem,
 .mg-fn-gor,
 .mg-fn-last {
@@ -822,7 +827,14 @@
     font-weight: 600;
 }
 
-.mg-fn-last {
+.mg-fn-last,
+.mg-fn-calls {
+    color: var(--ink-muted);
+}
+
+/* Approximate values, so they should not compete with the measured ones. */
+.mg-fn-p50,
+.mg-fn-p95 {
     color: var(--ink-muted);
 }
 

--- a/static/function-metrics.html
+++ b/static/function-metrics.html
@@ -120,6 +120,8 @@
       <span class="mg-eyebrow">SORT</span>
       <select id="mg-fn-sort" class="mg-fn-select" aria-label="Sort functions">
         <option value="exec">exec time</option>
+        <option value="p95">p95</option>
+        <option value="calls">calls</option>
         <option value="mem">memory</option>
         <option value="gor">goroutines</option>
         <option value="last">last ran</option>
@@ -136,7 +138,15 @@
            as empty columns implying a value is coming. -->
       <div class="mg-fn-thead" role="row">
         <span role="columnheader">FUNCTION</span>
+        <span role="columnheader" class="mg-num">CALLS</span>
         <span role="columnheader" class="mg-num">EXEC TIME</span>
+        <!-- Titled, because "approximate" is load-bearing: these come from a
+             fixed-bucket histogram, so each is the upper bound of its bucket
+             rather than an interpolated value. -->
+        <span role="columnheader" class="mg-num"
+              title="Approximate: bucket upper bound, not an interpolated value">P50</span>
+        <span role="columnheader" class="mg-num"
+              title="Approximate: bucket upper bound, not an interpolated value">P95</span>
         <span role="columnheader" class="mg-num">MEM &Delta;</span>
         <span role="columnheader" class="mg-num">GORO &Delta;</span>
         <span role="columnheader" class="mg-num">LAST RAN</span>
@@ -154,7 +164,10 @@
           <span class="mg-fn-name"></span>
           <span class="mg-fn-pkg"></span>
         </span>
+        <span class="mg-fn-calls mg-num" role="cell"></span>
         <span class="mg-fn-exec mg-num" role="cell"></span>
+        <span class="mg-fn-p50 mg-num" role="cell"></span>
+        <span class="mg-fn-p95 mg-num" role="cell"></span>
         <span class="mg-fn-mem  mg-num" role="cell"></span>
         <span class="mg-fn-gor  mg-num" role="cell"></span>
         <span class="mg-fn-last mg-num" role="cell"></span>

--- a/static/js/functions-view.js
+++ b/static/js/functions-view.js
@@ -119,6 +119,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const SORTS = {
         exec: (a, b) => b.exec - a.exec,
+        calls: (a, b) => b.calls - a.calls,
+        p95: (a, b) => b.p95 - a.p95,
         mem: (a, b) => b.mem - a.mem,
         gor: (a, b) => b.gor - a.gor,
         last: (a, b) => b.lastMs - a.lastMs,
@@ -133,6 +135,12 @@ document.addEventListener('DOMContentLoaded', () => {
                 pkg: parts.pkg,
                 name: parts.name,
                 exec: Number(m.execution_time) || 0,
+                calls: Number(m.call_count) || 0,
+                p50: Number(m.approximate_p50_ns) || 0,
+                p95: Number(m.approximate_p95_ns) || 0,
+                // False until enough calls have been seen for a percentile to
+                // be a summary rather than an anecdote.
+                percentilesReliable: m.percentiles_reliable === true,
                 mem: Number(m.memory_usage) || 0,
                 // Profiling runs on one call in SamplingRate (100 by default),
                 // so most functions have never had their allocation measured.
@@ -172,6 +180,30 @@ document.addEventListener('DOMContentLoaded', () => {
             node.querySelector('.mg-fn-name').textContent = r.name;
             node.querySelector('.mg-fn-pkg').textContent = r.pkg;
             node.querySelector('.mg-fn-exec').textContent = formatDuration(r.exec);
+            node.querySelector('.mg-fn-calls').textContent =
+                r.calls ? r.calls.toLocaleString() : '—';
+
+            /*
+             * A percentile over a handful of calls is the slowest of a handful,
+             * not a percentile. Below the server's floor these read em dash
+             * rather than a number, for the same reason the runtime chart
+             * refuses to draw a trend through two points.
+             *
+             * The tilde is not decoration: the value is a bucket upper bound,
+             * so "~4ms" means "at most 4ms".
+             */
+            const p50 = node.querySelector('.mg-fn-p50');
+            const p95 = node.querySelector('.mg-fn-p95');
+            if (r.percentilesReliable) {
+                p50.textContent = '~' + formatDuration(r.p50);
+                p95.textContent = '~' + formatDuration(r.p95);
+                p50.title = p95.title = 'Approximate: upper bound of the bucket this quantile falls in';
+            } else {
+                p50.textContent = '—';
+                p95.textContent = '—';
+                p50.title = p95.title = 'Too few calls yet for a percentile to mean anything';
+            }
+
             const memCell = node.querySelector('.mg-fn-mem');
             memCell.textContent = r.memSampled ? formatBytes(r.mem) : '—';
             memCell.title = r.memSampled

--- a/static/reports.html
+++ b/static/reports.html
@@ -84,16 +84,24 @@
       <span class="mg-top__title">Reports</span>
       <span class="mg-top__sub" id="mg-asof"></span>
       <div class="mg-top__right">
-        <div class="mg-range" id="mg-range" role="group" aria-label="Chart time range">
-          <button type="button" class="mg-range-seg" data-range="5m" aria-pressed="false">5m</button>
-          <button type="button" class="mg-range-seg is-active" data-range="15m" aria-pressed="true">15m</button>
-          <button type="button" class="mg-range-seg" data-range="1h" aria-pressed="false">1h</button>
-          <button type="button" class="mg-range-seg" data-range="24h" aria-pressed="false">24h</button>
-        </div>
-        <button type="button" class="mg-live is-live" id="mg-live" aria-pressed="true"
-                aria-label="Toggle live polling">
-          <i aria-hidden="true"></i><span id="mg-live-label">LIVE</span>
-        </button>
+    <!-- These must match RANGE_MINUTES in reports-view.js. They did not: the
+         shell rebuild gave this page the Overview's group, leaving a 5m button
+         the JS had no entry for -- clicking it produced an Invalid Date and
+         threw a RangeError out of the handler, so the page silently stopped --
+         and a 6h entry with no button. No 5m: at the default 5m sync interval
+         that window can never hold two samples. -->
+    <div class="mg-range" id="mg-range" role="group" aria-label="Report window">
+      <button type="button" class="mg-range-seg" data-range="15m" aria-pressed="false">15m</button>
+      <button type="button" class="mg-range-seg is-active" data-range="1h" aria-pressed="true">1h</button>
+      <button type="button" class="mg-range-seg" data-range="6h" aria-pressed="false">6h</button>
+      <button type="button" class="mg-range-seg" data-range="24h" aria-pressed="false">24h</button>
+    </div>
+        <!-- No LIVE control. A report answers a question about a window you
+             chose; re-fetching every fifteen seconds would move the ground
+             under whoever is reading it. The pill that sat here was
+             permanently green and wired to nothing, asserting a freshness the
+             page never had. The as-of stamp says when it was actually
+             fetched. -->
         <button type="button" class="mg-iconbtn" id="mg-theme-toggle" title="Toggle theme"
                 aria-label="Toggle theme">
           <svg class="mg-icon" aria-hidden="true"><use href="#i-moon" id="mg-theme-icon"></use></svg>

--- a/timeseries/monigo/data/p-0-0/meta.json
+++ b/timeseries/monigo/data/p-0-0/meta.json
@@ -1,0 +1,1 @@
+{"minTimestamp":0,"maxTimestamp":0,"numDataPoints":0,"metrics":{},"createdAt":"2026-08-29T13:18:58.649136+05:30"}

--- a/timeseries/monigodb.go
+++ b/timeseries/monigodb.go
@@ -2,6 +2,7 @@ package timeseries
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -101,6 +102,23 @@ func (s *StorageWrapper) InsertRows(rows []Row) error {
 func (s *StorageWrapper) Select(metric string, labels []Label, start, end int64) ([]DataPoint, error) {
 	points, err := s.storage.Select(metric, toTStorageLabels(labels), start, end)
 	if err != nil {
+		/*
+		 * An empty window is not a failure. tstorage reports "no data points"
+		 * as an error; the in-memory backend returns an empty slice for the
+		 * same condition. Passing the error through made the two backends
+		 * disagree, and on the default disk backend it surfaced as HTTP 500
+		 * from /service-metrics for any range the service has not been running
+		 * long enough to fill -- a freshly started process asking for 24h.
+		 *
+		 * The dashboard treats a failed series fetch as a lost connection and
+		 * escalates to the disconnected banner, so "no history yet" was
+		 * reported to the operator as "the service stopped answering". The
+		 * empty result is the honest answer, and the front end already has a
+		 * state for it.
+		 */
+		if errors.Is(err, tstorage.ErrNoDataPoints) {
+			return nil, nil
+		}
 		return nil, err
 	}
 	return fromTStorageDataPoints(points), nil

--- a/timeseries/timeseries_test.go
+++ b/timeseries/timeseries_test.go
@@ -246,3 +246,52 @@ func TestStorageInstanceIsReinitialisableAfterClose(t *testing.T) {
 		t.Fatalf("CloseStorage (cleanup) error: %v", err)
 	}
 }
+
+// An empty window is not a failure, and the two backends must agree on that.
+//
+// tstorage reports "no data points" as an error while the in-memory backend
+// returns an empty slice. Passing the error through made GET /service-metrics
+// answer 500 for any range the service has not been running long enough to
+// fill -- a freshly started process asking for 24h. The dashboard reads a
+// failed series fetch as a lost connection, so "no history yet" reached the
+// operator as "the service stopped answering".
+func TestEmptyWindowIsNotAnErrorOnEitherBackend(t *testing.T) {
+	far := time.Now().Add(-300 * 24 * time.Hour).Unix()
+	end := far + 3600
+	labels := []Label{{Name: "host", Value: "somewhere"}}
+
+	check := func(t *testing.T, s Storage) {
+		t.Helper()
+		points, err := s.Select("metric_that_was_never_written", labels, far, end)
+		if err != nil {
+			t.Errorf("empty window returned an error: %v\n"+
+				"Both backends must answer an empty window with (nil, nil). "+
+				"Otherwise /service-metrics returns 500 and the dashboard "+
+				"reports the service as disconnected when it simply has no "+
+				"history for that range yet.", err)
+		}
+		if len(points) != 0 {
+			t.Errorf("expected no points, got %d", len(points))
+		}
+	}
+
+	t.Run("memory", func(t *testing.T) {
+		check(t, NewInMemoryStorage())
+	})
+
+	t.Run("disk", func(t *testing.T) {
+		SetStorageType("disk")
+		manager = &storageManager{}
+		t.Cleanup(func() {
+			CloseStorage()
+			SetStorageType("memory")
+			manager = &storageManager{}
+		})
+
+		s, err := GetStorageInstance()
+		if err != nil {
+			t.Fatalf("GetStorageInstance: %v", err)
+		}
+		check(t, s)
+	})
+}


### PR DESCRIPTION
Closes #68.

Adds the `CALLS`, `P50` and `P95` columns the design asks for — plus three defects found on the way, two of which are live bugs on `main`.

## Percentiles: buckets, not stored samples

Keeping raw durations would give exact percentiles, but at `maxTrackedFunctions` (10 000) a ring of 128 `int64`s per function is **~10 MB held permanently** — in a library whose argument is that it is cheap to embed, and which just cut its dashboard payload from 7.9 MB to 356 KB. A fixed bucket array costs the same however often a function is called: **~800 KB** for the same 10 000.

The returned values are **bucket upper bounds, not interpolations**. Read `~4ms` as "at most 4ms". Interpolating would produce a precise-looking number the data cannot support, so the fields are named `Approximate*` and the UI prefixes a tilde.

**Below 20 calls the summary refuses to answer** and the column reads `—`. p95 of three calls is the slowest of three; presenting it as a percentile invites it to be read as a stable property of the function. Same rule the runtime chart already uses when it will not draw a trend through two points.

## Two things that were already there

- **`callCounters[name]` has always existed** to drive sampling and was simply never exposed. `CALLS` is one field.
- **Timing was already unsampled** — `elapsed` is measured outside the `shouldProfile` guard, so the distribution covers *every* call, not the 1-in-100 that get profiled.

## Three fixes

**An empty window returned HTTP 500.** `tstorage` reports "no data points" as an error; the in-memory backend returns an empty slice. The error was passed through, so on the **default disk backend** any range the service had not been running long enough to fill answered 500 — a freshly started process asking for 24h. The dashboard reads a failed series fetch as a lost connection, so *"no history yet"* reached the operator as *"the service stopped answering"*. Both backends now answer `(nil, nil)`, pinned by a test that runs against each.

```
before:  empty window -> HTTP 500  "Failed to get data points"
after:   empty window -> HTTP 200  []
```

**`pprof.StartCPUProfile`'s error was discarded.** CPU profiling is a process-wide singleton, so a second traced call sampled concurrently got `cpu profiling already in use`, the error vanished, and the caller recorded a profile path pointing at the zero-byte file `os.Create` had just truncated — or at one the other call was actively writing. Under concurrent load that is the normal case. The error propagates now, the truncated file is removed, and the caller leaves the path empty so the UI says "not profiled", which is true.

**The Reports range control was broken by the shell rebuild** (my regression, from #66). It inherited the Overview's group, leaving a `5m` button `RANGE_MINUTES` has no entry for — clicking it produced an `Invalid Date` and threw a `RangeError` out of the handler, so the page silently stopped — and a `6h` entry with no button. The active segment also disagreed with the initial state. Its LIVE pill is gone as well: permanently green, wired to nothing, asserting a freshness a fetch-once page never had.

## Tests

Seven new, each pinning a property rather than an implementation. One is worth calling out:

`TestP95SitsBelowATailOfExactlyFivePercent` — with exactly 5% of calls slow, the 950th ordered value of 1000 is still a *fast* one; the tail begins at 951. I wrote the obvious expectation first and it was wrong, so the case is pinned to stop a future rounding change slipping past.

Full suite green; payload unchanged.