### PR TITLE
docs: release 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0] - 2026-08-29
+
+### Added
+- **Per-function call counts and approximate latency percentiles.** `CALLS`,
+  `P50` and `P95` on the Functions table. The distribution comes from a
+  fixed-bucket histogram -- 216 bytes per function regardless of call volume,
+  against ~10 MB at the function cap for keeping raw samples -- so the values
+  are bucket upper bounds rather than interpolations, shown as `~4ms` meaning
+  "at most 4ms". Below 20 calls the columns read `—`: p95 of three calls is the
+  slowest of three, not a percentile
+
 ### Fixed
 - **`GET /metrics` answered HTTP 500 under `RegisterDashboardHandlers` and 404
   under Fiber**, while the same path answered 200 under `RegisterAPIHandlers`.
@@ -19,17 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The API surface was declared separately in five registration sites, which is
   how the above drifted. `routes.go` now declares it once and all five derive
   from it, and a test drives every route through every registration style
-
-### Added
-- **Per-function call counts and approximate latency percentiles.** `CALLS`,
-  `P50` and `P95` on the Functions table. The distribution comes from a
-  fixed-bucket histogram -- 216 bytes per function regardless of call volume,
-  against ~10 MB at the function cap for keeping raw samples -- so the values
-  are bucket upper bounds rather than interpolations, shown as `~4ms` meaning
-  "at most 4ms". Below 20 calls the columns read `—`: p95 of three calls is the
-  slowest of three, not a percentile
-
-### Fixed
 - **A window predating service start returned HTTP 500.** Both read endpoints
   clamp the requested start up to the service start time, so a window *ending*
   before startup became `start > end`, which the storage layer rejects. The
@@ -52,13 +52,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   suite modified a tracked file and left the working tree dirty
 
 ### Known gaps
-Two things the design canvas shows that the dashboard deliberately does not,
-because the data behind them does not exist yet. Both are tracked rather than
-faked, and the columns are absent rather than filled with plausible numbers:
+One thing the design canvas shows that the dashboard deliberately does not,
+because the data behind it does not exist yet. It is tracked rather than faked,
+and the page is absent rather than filled with plausible numbers:
 
 - **Exporters page** — needs Prometheus and OTel status surfaced server-side (#67)
-- **Per-function `CALLS`, `P50`, `P95`** — `FunctionMetrics` overwrites on every
-  call, so there is no distribution to derive them from (#68)
 
 ## [1.5.0] - 2026-08-29
 


### PR DESCRIPTION
Stamps the work sitting on `main` since v1.5.0 as **1.6.0** and opens a fresh `Unreleased` heading.

Rebased onto `main` after #77 merged, so the `/metrics` routing fix is folded into 1.6.0 rather than waiting for a 1.6.1.

## Why now

Two of these are first-run defects.

**`GET /metrics` answered HTTP 500** under `RegisterDashboardHandlers` and 404 under Fiber, while answering 200 under `RegisterAPIHandlers`. Prometheus marks a target down on a 500, so anyone mounting the dashboard through the unified handler had a scrape endpoint that looked dead.

**A range longer than the process uptime returned HTTP 500** — which is every fresh install asking for 24h. The dashboard reads a failed series fetch as a lost connection, so a healthy service reported itself as having stopped answering.

## What ships

**Added** — per-function `CALLS`, `P50`, `P95`. Bucket upper bounds from a fixed-bucket histogram (216 bytes per function regardless of call volume), shown as `~4ms` meaning "at most 4ms", and `—` below 20 calls rather than a percentile of three samples.

**Fixed** — the two 500s above; the five-way route registration split that caused the first one; the two storage backends disagreeing on empty results; `pprof.StartCPUProfile`'s discarded error recording a path to a zero-byte file; the Reports `5m` button that threw and silently stopped the page; the runtime chart not refreshing under LIVE; and committed `tstorage` test data that left the tree dirty after every run.

## One correction folded in

"Known gaps" listed per-function `CALLS`/`P50`/`P95` (#68) as something the dashboard deliberately does not show — but it shipped in this same release and is listed under Added directly above. The section contradicted itself. Removed, and the intro reworded from "two things" to "one thing", leaving Exporters (#67) as the single remaining gap.

## After merge

Tag `v1.6.0` on the merge commit and publish the release.