### PR TITLE
fix(routing): serve /metrics from every router, from one route table

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,3 +30,46 @@ jobs:
       with:
         name: coverage
         path: coverage.out
+
+  # The example programs are nested modules with their own go.mod, so the root
+  # `go test ./...` above never compiles them -- and each one has a `replace`
+  # pointing at the working tree, so they are the only check that a change to
+  # MoniGo's public API does not break the code consumers copy from.
+  #
+  # Modules are discovered rather than listed: a new example is covered the
+  # moment it has a go.mod, with nothing to remember to update here.
+  examples:
+    name: Build example modules
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v5
+      with:
+        go-version: '1.24'
+    - name: Build and vet every nested module
+      run: |
+        status=0
+        found=0
+        while IFS= read -r mod; do
+          dir=$(dirname "$mod")
+          found=$((found + 1))
+          echo "::group::$dir"
+          # -o a scratch dir: a bare `go build ./...` drops a binary next to
+          # each main package, which is how compiled examples ended up tracked
+          # in the first place (#72).
+          if (cd "$dir" && go build -o "$(mktemp -d)" ./... && go vet ./...); then
+            echo "ok $dir"
+          else
+            echo "::error file=$mod::$dir failed to build"
+            status=1
+          fi
+          echo "::endgroup::"
+        done < <(find . -name go.mod -not -path './go.mod' | sort)
+
+        echo "checked $found nested module(s)"
+        # A discovery bug that finds nothing would otherwise pass silently.
+        if [ "$found" -eq 0 ]; then
+          echo "::error::no nested modules found -- the discovery step is broken"
+          exit 1
+        fi
+        exit $status

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`GET /metrics` answered HTTP 500 under `RegisterDashboardHandlers` and 404
+  under Fiber**, while the same path answered 200 under `RegisterAPIHandlers`.
+  The Prometheus endpoint is served at the root rather than beneath the API
+  base path, and the unified handlers dispatched to the API only on that
+  prefix, so the scrape endpoint fell through to the static file server. Any
+  consumer mounting the dashboard through `RegisterDashboardHandlers` or
+  `RegisterSecuredDashboardHandlers` -- or through Fiber -- had Prometheus
+  marking the target down
+- The API surface was declared separately in five registration sites, which is
+  how the above drifted. `routes.go` now declares it once and all five derive
+  from it, and a test drives every route through every registration style
+
 ### Added
 - **Per-function call counts and approximate latency percentiles.** `CALLS`,
   `P50` and `P95` on the Functions table. The distribution comes from a

--- a/monigo.go
+++ b/monigo.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v2"
-	"github.com/iyashjayesh/monigo/api"
 	"github.com/iyashjayesh/monigo/common"
 	"github.com/iyashjayesh/monigo/core"
 	"github.com/iyashjayesh/monigo/exporters"
@@ -426,14 +425,9 @@ func (m *Monigo) registerShutdownHandler(srv *http.Server) {
 
 // registerAPIEndpoints registers the standard API endpoints on the mux.
 func registerAPIEndpoints(mux *http.ServeMux, apiPath string) {
-	mux.HandleFunc(fmt.Sprintf("%s/metrics", apiPath), api.GetServiceStatistics)
-	mux.HandleFunc(fmt.Sprintf("%s/service-info", apiPath), api.GetServiceInfoAPI)
-	mux.HandleFunc(fmt.Sprintf("%s/service-metrics", apiPath), api.GetServiceMetricsFromStorage)
-	mux.HandleFunc(fmt.Sprintf("%s/go-routines-stats", apiPath), api.GetGoRoutinesStats)
-	mux.HandleFunc(fmt.Sprintf("%s/function", apiPath), api.GetFunctionTraceDetails)
-	mux.HandleFunc(fmt.Sprintf("%s/function-details", apiPath), api.ViewFunctionMetrics)
-	mux.HandleFunc("/metrics", api.PrometheusMetricsHandler)
-	mux.HandleFunc(fmt.Sprintf("%s/reports", apiPath), api.GetReportData)
+	for path, handler := range apiHandlerMap(apiPath) {
+		mux.HandleFunc(path, handler)
+	}
 }
 
 // RegisterDashboardHandlers registers all dashboard handlers to the provided HTTP mux
@@ -483,16 +477,7 @@ func GetAPIHandlers(customBaseAPIPath ...string) map[string]http.HandlerFunc {
 		apiPath = customBaseAPIPath[0]
 	}
 
-	return map[string]http.HandlerFunc{
-		fmt.Sprintf("%s/metrics", apiPath):           api.GetServiceStatistics,
-		fmt.Sprintf("%s/service-info", apiPath):      api.GetServiceInfoAPI,
-		fmt.Sprintf("%s/service-metrics", apiPath):   api.GetServiceMetricsFromStorage,
-		fmt.Sprintf("%s/go-routines-stats", apiPath): api.GetGoRoutinesStats,
-		fmt.Sprintf("%s/function", apiPath):          api.GetFunctionTraceDetails,
-		fmt.Sprintf("%s/function-details", apiPath):  api.ViewFunctionMetrics,
-		"/metrics":                         api.PrometheusMetricsHandler,
-		fmt.Sprintf("%s/reports", apiPath): api.GetReportData,
-	}
+	return apiHandlerMap(apiPath)
 }
 
 // GetStaticHandler returns the static file handler function
@@ -508,7 +493,7 @@ func GetUnifiedHandler(customBaseAPIPath ...string) http.HandlerFunc {
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, apiPath) {
+		if isAPIPath(r.URL.Path, apiPath) {
 			routeToAPIHandler(w, r, apiPath)
 			return
 		}
@@ -525,7 +510,7 @@ func GetFiberHandler(customBaseAPIPath ...string) func(*fiber.Ctx) error {
 
 	return func(c *fiber.Ctx) error {
 		path := string(c.Request().URI().Path())
-		if strings.HasPrefix(path, apiPath) {
+		if isAPIPath(path, apiPath) {
 			return routeToFiberAPIHandler(c, path, apiPath)
 		}
 		return serveFiberStaticFiles(c, path)
@@ -540,7 +525,7 @@ func GetSecuredUnifiedHandler(m *Monigo, customBaseAPIPath ...string) http.Handl
 	}
 
 	baseHandler := func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, apiPath) {
+		if isAPIPath(r.URL.Path, apiPath) {
 			routeToAPIHandler(w, r, apiPath)
 			return
 		}
@@ -557,18 +542,9 @@ func GetSecuredAPIHandlers(m *Monigo, customBaseAPIPath ...string) map[string]ht
 		apiPath = customBaseAPIPath[0]
 	}
 
-	baseHandlers := map[string]http.HandlerFunc{
-		fmt.Sprintf("%s/metrics", apiPath):           api.GetServiceStatistics,
-		fmt.Sprintf("%s/service-info", apiPath):      api.GetServiceInfoAPI,
-		fmt.Sprintf("%s/service-metrics", apiPath):   api.GetServiceMetricsFromStorage,
-		fmt.Sprintf("%s/go-routines-stats", apiPath): api.GetGoRoutinesStats,
-		fmt.Sprintf("%s/function", apiPath):          api.GetFunctionTraceDetails,
-		fmt.Sprintf("%s/function-details", apiPath):  api.ViewFunctionMetrics,
-		"/metrics":                         api.PrometheusMetricsHandler,
-		fmt.Sprintf("%s/reports", apiPath): api.GetReportData,
-	}
+	baseHandlers := apiHandlerMap(apiPath)
 
-	securedHandlers := make(map[string]http.HandlerFunc)
+	securedHandlers := make(map[string]http.HandlerFunc, len(baseHandlers))
 	for path, handler := range baseHandlers {
 		securedHandlers[path] = applyMiddlewareChain(handler, m.APIMiddleware, nil)
 	}
@@ -608,48 +584,19 @@ func applyMiddlewareChain(handler http.HandlerFunc, middleware []func(http.Handl
 }
 
 func routeToAPIHandler(w http.ResponseWriter, r *http.Request, apiPath string) {
-	path := r.URL.Path
-
-	switch {
-	case path == fmt.Sprintf("%s/metrics", apiPath):
-		api.GetServiceStatistics(w, r)
-	case path == fmt.Sprintf("%s/service-info", apiPath):
-		api.GetServiceInfoAPI(w, r)
-	case path == fmt.Sprintf("%s/service-metrics", apiPath):
-		api.GetServiceMetricsFromStorage(w, r)
-	case path == fmt.Sprintf("%s/go-routines-stats", apiPath):
-		api.GetGoRoutinesStats(w, r)
-	case path == fmt.Sprintf("%s/function", apiPath):
-		api.GetFunctionTraceDetails(w, r)
-	case path == fmt.Sprintf("%s/function-details", apiPath):
-		api.ViewFunctionMetrics(w, r)
-	case path == fmt.Sprintf("%s/reports", apiPath):
-		api.GetReportData(w, r)
-	default:
-		http.NotFound(w, r)
+	if handler := lookupAPIHandler(r.URL.Path, apiPath); handler != nil {
+		handler(w, r)
+		return
 	}
+	http.NotFound(w, r)
 }
 
 func routeToFiberAPIHandler(c *fiber.Ctx, path, apiPath string) error {
-	switch {
-	case path == fmt.Sprintf("%s/metrics", apiPath):
-		return handleFiberAPI(c, api.GetServiceStatistics)
-	case path == fmt.Sprintf("%s/service-info", apiPath):
-		return handleFiberAPI(c, api.GetServiceInfoAPI)
-	case path == fmt.Sprintf("%s/service-metrics", apiPath):
-		return handleFiberAPI(c, api.GetServiceMetricsFromStorage)
-	case path == fmt.Sprintf("%s/go-routines-stats", apiPath):
-		return handleFiberAPI(c, api.GetGoRoutinesStats)
-	case path == fmt.Sprintf("%s/function", apiPath):
-		return handleFiberAPI(c, api.GetFunctionTraceDetails)
-	case path == fmt.Sprintf("%s/function-details", apiPath):
-		return handleFiberAPI(c, api.ViewFunctionMetrics)
-	case path == fmt.Sprintf("%s/reports", apiPath):
-		return handleFiberAPI(c, api.GetReportData)
-	default:
-		c.Status(404).SendString("Not Found")
-		return nil
+	if handler := lookupAPIHandler(path, apiPath); handler != nil {
+		return handleFiberAPI(c, handler)
 	}
+	c.Status(404).SendString("Not Found")
+	return nil
 }
 
 func handleFiberAPI(c *fiber.Ctx, handler func(http.ResponseWriter, *http.Request)) error {

--- a/routes.go
+++ b/routes.go
@@ -1,0 +1,87 @@
+package monigo
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/iyashjayesh/monigo/api"
+)
+
+// The dashboard's API surface, declared once.
+//
+// MoniGo exposes the same endpoints through five different registration
+// styles -- a plain ServeMux, two handler maps for third-party routers, and
+// two path switches behind the unified and Fiber handlers. Each one used to
+// carry its own copy of the endpoint list, so adding a route meant editing
+// five places and nothing failed when you edited four.
+//
+// That drift had already happened: the Prometheus endpoint was registered in
+// the three map-shaped sites but missing from both switches, so `GET /metrics`
+// answered 200 under RegisterAPIHandlers and 500 under
+// RegisterDashboardHandlers and Fiber.
+//
+// Everything below derives from apiRoutes(). Adding an endpoint here reaches
+// every router at once, and TestEveryRouteIsReachableFromEveryRouter fails if
+// a registration style is ever added that does not.
+
+// apiRoute is one endpoint served beneath the configured API base path.
+type apiRoute struct {
+	Suffix  string // appended to the API base path, e.g. "/service-info"
+	Handler http.HandlerFunc
+}
+
+// prometheusPath is served at the root rather than under the API base path:
+// scrapers are conventionally pointed at /metrics, and moving it would break
+// every existing scrape config.
+const prometheusPath = "/metrics"
+
+// apiRoutes returns the endpoints served under the API base path, in a stable
+// order. It deliberately excludes prometheusPath, which is not base-path
+// relative -- see apiHandlerMap and lookupAPIHandler, which add it.
+func apiRoutes() []apiRoute {
+	return []apiRoute{
+		{"/metrics", api.GetServiceStatistics},
+		{"/service-info", api.GetServiceInfoAPI},
+		{"/service-metrics", api.GetServiceMetricsFromStorage},
+		{"/go-routines-stats", api.GetGoRoutinesStats},
+		{"/function", api.GetFunctionTraceDetails},
+		{"/function-details", api.ViewFunctionMetrics},
+		{"/reports", api.GetReportData},
+	}
+}
+
+// apiHandlerMap builds the full path-to-handler map for a given base path,
+// including the root-level Prometheus endpoint.
+func apiHandlerMap(apiPath string) map[string]http.HandlerFunc {
+	routes := apiRoutes()
+	handlers := make(map[string]http.HandlerFunc, len(routes)+1)
+	for _, rt := range routes {
+		handlers[apiPath+rt.Suffix] = rt.Handler
+	}
+	handlers[prometheusPath] = api.PrometheusMetricsHandler
+	return handlers
+}
+
+// lookupAPIHandler resolves a request path to its handler, or nil when the
+// path is not part of the API surface.
+//
+// The exact match on prometheusPath is tested first so that a caller who
+// configures "/metrics" as their API base path still gets a working scrape
+// endpoint rather than shadowing it with "/metrics/metrics".
+func lookupAPIHandler(path, apiPath string) http.HandlerFunc {
+	if path == prometheusPath {
+		return api.PrometheusMetricsHandler
+	}
+	for _, rt := range apiRoutes() {
+		if path == apiPath+rt.Suffix {
+			return rt.Handler
+		}
+	}
+	return nil
+}
+
+// isAPIPath reports whether a request should be dispatched to the API rather
+// than to the static site.
+func isAPIPath(path, apiPath string) bool {
+	return path == prometheusPath || strings.HasPrefix(path, apiPath)
+}

--- a/routes_test.go
+++ b/routes_test.go
@@ -1,0 +1,157 @@
+package monigo
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+// expectedPaths is every path the dashboard is supposed to answer on, for the
+// default API base path.
+func expectedPaths(apiPath string) []string {
+	paths := []string{prometheusPath}
+	for _, rt := range apiRoutes() {
+		paths = append(paths, apiPath+rt.Suffix)
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+// servedStaticFallback reports whether a response is the static-file handler's
+// answer rather than an API handler's. That is the shape the drift took: the
+// unified handler fell through to serveHtmlSite, which replied
+// 500 "Could not load static/metrics" -- a Prometheus scrape would see the
+// target as down while the mux-registered dashboard answered the same path 200.
+func servedStaticFallback(code int, body string) bool {
+	return code == http.StatusNotFound || strings.Contains(body, "Could not load static/")
+}
+
+// TestEveryRouteIsReachableFromEveryRouter is the guardrail for the five-way
+// registration split. MoniGo exposes the same endpoints through a ServeMux,
+// two handler maps and two path switches; before apiRoutes() existed each kept
+// its own list, and /metrics was present in three of them and missing from two.
+//
+// If a new registration style is added, add it here.
+func TestEveryRouteIsReachableFromEveryRouter(t *testing.T) {
+	apiPath := baseAPIPath
+	want := expectedPaths(apiPath)
+
+	// 1. Plain ServeMux, as StartDashboard and RegisterAPIHandlers build it.
+	t.Run("ServeMux", func(t *testing.T) {
+		mux := http.NewServeMux()
+		registerAPIEndpoints(mux, apiPath)
+		for _, p := range want {
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, p, nil))
+			if servedStaticFallback(rec.Code, rec.Body.String()) {
+				t.Errorf("%s: unreachable (%d %q)", p, rec.Code, truncate(rec.Body.String()))
+			}
+		}
+	})
+
+	// 2. GetAPIHandlers -- the map handed to third-party routers.
+	t.Run("GetAPIHandlers", func(t *testing.T) {
+		assertMapCovers(t, GetAPIHandlers(), want)
+	})
+
+	// 3. GetSecuredAPIHandlers -- the same map with middleware applied.
+	t.Run("GetSecuredAPIHandlers", func(t *testing.T) {
+		assertMapCovers(t, GetSecuredAPIHandlers(&Monigo{}), want)
+	})
+
+	// 4. The unified handler behind RegisterDashboardHandlers. This is the one
+	//    that answered 500 on /metrics.
+	t.Run("UnifiedHandler", func(t *testing.T) {
+		h := GetUnifiedHandler()
+		for _, p := range want {
+			rec := httptest.NewRecorder()
+			h(rec, httptest.NewRequest(http.MethodGet, p, nil))
+			if servedStaticFallback(rec.Code, rec.Body.String()) {
+				t.Errorf("%s: fell through to the static handler (%d %q)",
+					p, rec.Code, truncate(rec.Body.String()))
+			}
+		}
+	})
+
+	// 5. The Fiber handler.
+	t.Run("FiberHandler", func(t *testing.T) {
+		app := fiber.New()
+		app.All("/*", GetFiberHandler())
+		for _, p := range want {
+			req := httptest.NewRequest(http.MethodGet, p, nil)
+			resp, err := app.Test(req, 5000)
+			if err != nil {
+				t.Fatalf("%s: %v", p, err)
+			}
+			if resp.StatusCode == http.StatusNotFound {
+				t.Errorf("%s: unreachable through the Fiber handler (404)", p)
+			}
+			resp.Body.Close()
+		}
+	})
+}
+
+func assertMapCovers(t *testing.T, got map[string]http.HandlerFunc, want []string) {
+	t.Helper()
+	for _, p := range want {
+		if got[p] == nil {
+			t.Errorf("%s: absent from the handler map", p)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("handler map has %d entries, expected %d -- an endpoint is "+
+			"registered here that apiRoutes() does not declare", len(got), len(want))
+	}
+}
+
+// TestLookupAndHandlerMapAgree keeps the two derivations of the route table in
+// step. apiHandlerMap builds a map; lookupAPIHandler walks the slice. A route
+// resolvable by one and not the other is the same class of bug the table was
+// introduced to remove, one level down.
+func TestLookupAndHandlerMapAgree(t *testing.T) {
+	for _, apiPath := range []string{baseAPIPath, "/custom/base", "/metrics"} {
+		t.Run(apiPath, func(t *testing.T) {
+			for path := range apiHandlerMap(apiPath) {
+				if lookupAPIHandler(path, apiPath) == nil {
+					t.Errorf("%q is in apiHandlerMap but lookupAPIHandler misses it", path)
+				}
+				if !isAPIPath(path, apiPath) {
+					t.Errorf("%q is a route but isAPIPath says it is not, so the "+
+						"unified handler will send it to the static site", path)
+				}
+			}
+		})
+	}
+}
+
+// TestPrometheusPathSurvivesAnOverlappingBasePath pins the ordering inside
+// lookupAPIHandler. A consumer who sets "/metrics" as their API base path
+// would otherwise have the scrape endpoint shadowed by "/metrics/metrics".
+func TestPrometheusPathSurvivesAnOverlappingBasePath(t *testing.T) {
+	if lookupAPIHandler(prometheusPath, "/metrics") == nil {
+		t.Fatal("the Prometheus endpoint is unreachable when the API base path is /metrics")
+	}
+}
+
+// TestUnknownAPIPathIsNotFound guards the other direction: the table must not
+// make the router answer on paths it does not declare.
+func TestUnknownAPIPathIsNotFound(t *testing.T) {
+	rec := httptest.NewRecorder()
+	path := fmt.Sprintf("%s/no-such-endpoint", baseAPIPath)
+	GetUnifiedHandler()(rec, httptest.NewRequest(http.MethodGet, path, nil))
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("%s answered %d, expected 404", path, rec.Code)
+	}
+}
+
+func truncate(s string) string {
+	if len(s) > 60 {
+		return s[:60] + "..."
+	}
+	return strings.TrimSpace(s)
+}


### PR DESCRIPTION
Closes #74. Closes #75.

Planning #74 as a latent hazard turned up a live bug, so this fixes that too.

## The bug

The API surface was declared five times — a ServeMux registration, two handler maps for third-party routers, and two path switches behind the unified and Fiber handlers. The Prometheus endpoint was in the three map-shaped sites and missing from both switches:

| Registered via | `GET /metrics` |
| --- | --- |
| `RegisterAPIHandlers` | **200** |
| `RegisterDashboardHandlers` | **500** `Could not load static/metrics` |
| Fiber handler | **404** |

`RegisterDashboardHandlers` and `RegisterSecuredDashboardHandlers` both go through the unified handler, so anyone mounting the dashboard that way had a scrape endpoint returning 500 — **Prometheus marks that target down.** The bare path isn't under the API base path, and the unified handlers only dispatched to the API on that prefix, so it fell through to the static file server.

## The fix

`routes.go` declares the surface once. `apiHandlerMap` feeds the three map/mux sites, `lookupAPIHandler` the two switches, `isAPIPath` the three dispatch guards. **Net 70 lines removed** from `monigo.go`.

`lookupAPIHandler` checks the Prometheus path before the base-path suffixes, so configuring `/metrics` as your API base path keeps a working scrape endpoint rather than shadowing it with `/metrics/metrics`.

## The guardrail actually fails on the bug

`TestEveryRouteIsReachableFromEveryRouter` drives every declared route through all five registration styles. Reverting the dispatch guard to its old prefix-only form:

```
--- FAIL: TestEveryRouteIsReachableFromEveryRouter/UnifiedHandler
    /metrics: fell through to the static handler (500 "Could not load static/metrics")
--- FAIL: TestEveryRouteIsReachableFromEveryRouter/FiberHandler
    /metrics: unreachable through the Fiber handler (404)
--- FAIL: TestLookupAndHandlerMapAgree//monigo/api/v1
    "/metrics" is a route but isAPIPath says it is not, so the unified handler
    will send it to the static site
```

## #75 — the examples job

The 13 example modules have their own `go.mod`, so the root `go test ./...` never compiled them. Each carries a `replace` pointing at the working tree, which makes them the only check that a public API change doesn't break the code consumers copy from.

Renaming `APIKeyMiddleware` demonstrates the gap — the root build stays **green** (today's CI passes) while the new job goes **red** on `security-examples/api-key`.

All 13 build today, so this starts green. Modules are discovered with `find` rather than listed, so a new example is covered the moment it has a `go.mod`. Build output goes to a scratch dir via `-o`, so the job doesn't recreate the tracked binaries of #72.

## Verification

`go test -race ./...` green across all 12 packages. `go vet` clean. All 13 example modules build and vet.