### PR TITLE
fix(exporters): connect the push pipeline so OTel actually exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`WithOTelEndpoint` connected to the collector and never sent a metric.**
+  `Registry`, `Pipeline` and `MultiExporter` were each implemented and each
+  unit-tested, and nothing ever constructed them, so `OTelExporter.Export` was
+  unreachable from a running service. The exporter was created, logged as
+  `OTel exporter initialized`, and shut down again without being asked for
+  anything in between; because its instruments are registered lazily on the
+  first `Export`, its periodic reader collected an empty set forever. Measured
+  against a real OTLP receiver: **0 metrics before, 5 within 30s after**
+
 ## [1.6.0] - 2026-08-29
 
 ### Added

--- a/export_pipeline.go
+++ b/export_pipeline.go
@@ -1,0 +1,117 @@
+package monigo
+
+import (
+	"context"
+	"time"
+
+	"github.com/iyashjayesh/monigo/core"
+	"github.com/iyashjayesh/monigo/internal/exporter"
+	"github.com/iyashjayesh/monigo/internal/logger"
+	"github.com/iyashjayesh/monigo/internal/pipeline"
+	"github.com/iyashjayesh/monigo/internal/registry"
+)
+
+// Wiring for push-based exporters.
+//
+// Registry, Pipeline and MultiExporter each existed and each was unit-tested,
+// but nothing ever constructed them, so OTelExporter.Export was unreachable and
+// WithOTelEndpoint pushed nothing while logging that it had initialised fine.
+// This file is the missing connection.
+
+// defaultExportInterval is how often the registry is refreshed and handed to
+// the push exporters.
+//
+// It matches the OTel PeriodicReader interval in NewOTelExporter, so every
+// push carries a sample taken since the last one. DataPointsSyncFrequency is
+// deliberately not reused: that governs flushes to the local time-series
+// store, defaults to 5m, and at that spacing the reader would re-send the same
+// value ten times over before it changed.
+const defaultExportInterval = 30 * time.Second
+
+// pushExporters returns the configured push-based exporters. Prometheus is
+// absent by design: it is scraped, not pushed to, so it has no place in an
+// export pipeline.
+func (m *Monigo) pushExporters() []exporter.Exporter {
+	var exps []exporter.Exporter
+	if m.otelExporter != nil {
+		exps = append(exps, m.otelExporter)
+	}
+	return exps
+}
+
+// startExportPipeline wires registry -> pipeline -> exporters and starts it.
+// It is a no-op when nothing is configured to push.
+func (m *Monigo) startExportPipeline() {
+	m.exportPipeline = startExportPipelineWith(
+		m.pushExporters(), m.ServiceName, defaultExportInterval)
+}
+
+// startExportPipelineWith is startExportPipeline with the exporter list and
+// interval supplied, so the wiring can be exercised without a live collector.
+// Returns nil when there is nothing to push to.
+func startExportPipelineWith(exps []exporter.Exporter, serviceName string, interval time.Duration) *pipeline.Pipeline {
+	if len(exps) == 0 {
+		return nil
+	}
+
+	reg := registry.NewRegistry()
+	multi := exporter.NewMultiExporter(exps...)
+	p := pipeline.NewPipeline(reg, multi, interval).
+		WithCollector(func() { publishRuntimeMetrics(reg, serviceName) })
+
+	// Export once up front, before the ticker starts.
+	//
+	// This is not just about filling the opening interval. The OTel exporter
+	// creates its instruments lazily on the first Export, and its own reader
+	// runs on an independent clock: if the first Export waited for the first
+	// tick, the reader's opening cycle would find no instruments and ship an
+	// empty batch, putting real data two full cycles out. Measured against a
+	// live OTLP receiver, this moves first delivery from ~60s to ~30s.
+	publishRuntimeMetrics(reg, serviceName)
+	if err := multi.Export(context.Background(), reg.GetAll()); err != nil {
+		// Logged, not fatal: a collector that is not up yet is ordinary, and
+		// the pipeline retries on every tick.
+		logger.Log.Warn("initial metric export failed", "error", err)
+	}
+	p.Start(context.Background())
+
+	names := make([]string, 0, len(exps))
+	for _, e := range exps {
+		names = append(names, e.Name())
+	}
+	logger.Log.Info("export pipeline started", "exporters", names, "interval", interval)
+	return p
+}
+
+// stopExportPipeline stops the pipeline if one is running. Safe to call when
+// none was started.
+func (m *Monigo) stopExportPipeline() {
+	if m.exportPipeline != nil {
+		m.exportPipeline.Stop()
+		m.exportPipeline = nil
+	}
+}
+
+// publishRuntimeMetrics snapshots the runtime into the registry.
+//
+// The metric names and values deliberately mirror MonigoCollector.Collect in
+// exporters/prometheus.go one for one, so a scrape and a push report identical
+// numbers under identical names. Anything added to one belongs in the other.
+//
+// Everything is published as a gauge, including the two disk totals that
+// Prometheus exposes as counters. That is not an oversight: the OTel exporter
+// maps registry.Counter onto Float64Counter and calls Add(value), which is
+// additive, while Registry.IncrementCounter already accumulates internally.
+// Feeding a cumulative total through that pair would re-add the whole total on
+// every cycle and grow quadratically. A gauge carrying the true cumulative
+// value is the honest reading; making the counter path safe is separate work.
+func publishRuntimeMetrics(r *registry.Registry, serviceName string) {
+	stats := core.GetServiceStats(context.Background())
+	labels := map[string]string{"service": serviceName}
+
+	r.SetGauge("monigo_cpu_usage_percent", stats.LoadStatistics.SystemCPULoadRaw, labels)
+	r.SetGauge("monigo_memory_usage_bytes", stats.MemoryStatistics.MemoryUsedBySystemRaw, labels)
+	r.SetGauge("monigo_goroutines_count", float64(stats.CoreStatistics.Goroutines), labels)
+	r.SetGauge("monigo_disk_read_bytes_total", float64(stats.DiskIO.ReadBytes), labels)
+	r.SetGauge("monigo_disk_write_bytes_total", float64(stats.DiskIO.WriteBytes), labels)
+}

--- a/export_pipeline_test.go
+++ b/export_pipeline_test.go
@@ -1,0 +1,157 @@
+package monigo
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/iyashjayesh/monigo/internal/exporter"
+	"github.com/iyashjayesh/monigo/internal/registry"
+)
+
+// recordingExporter stands in for a push exporter and remembers what it was
+// handed.
+type recordingExporter struct {
+	mu    sync.Mutex
+	calls int
+	names map[string]bool
+	err   error
+}
+
+func newRecordingExporter() *recordingExporter {
+	return &recordingExporter{names: map[string]bool{}}
+}
+
+func (r *recordingExporter) Export(_ context.Context, metrics []*registry.MetricValue) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls++
+	for _, m := range metrics {
+		r.names[m.Name] = true
+	}
+	return r.err
+}
+
+func (r *recordingExporter) Name() string { return "recording" }
+
+func (r *recordingExporter) snapshot() (int, []string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, 0, len(r.names))
+	for n := range r.names {
+		out = append(out, n)
+	}
+	sort.Strings(out)
+	return r.calls, out
+}
+
+// TestAConfiguredExporterActuallyReceivesMetrics is the regression test for the
+// gap that made every push exporter inert: Registry, Pipeline and
+// MultiExporter were each unit-tested, and nothing constructed them, so
+// Export() was unreachable from a running MoniGo. Every existing test covered a
+// part; none covered the wiring.
+func TestAConfiguredExporterActuallyReceivesMetrics(t *testing.T) {
+	rec := newRecordingExporter()
+
+	p := startExportPipelineWith([]exporter.Exporter{rec}, "test-svc", 20*time.Millisecond)
+	if p == nil {
+		t.Fatal("no pipeline was started for a configured exporter")
+	}
+	defer p.Stop()
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if calls, _ := rec.snapshot(); calls > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	calls, names := rec.snapshot()
+	if calls == 0 {
+		t.Fatal("the exporter was never called: the pipeline is not wired to it")
+	}
+	if len(names) == 0 {
+		t.Fatal("the exporter was called with no metrics")
+	}
+	t.Logf("%d export(s), metrics: %v", calls, names)
+}
+
+// TestPushedMetricsMatchTheScrapedOnes pins the two exporter paths together.
+// A push and a scrape that disagree about names would be worse than either
+// being absent, because the two would be silently incomparable.
+func TestPushedMetricsMatchTheScrapedOnes(t *testing.T) {
+	reg := registry.NewRegistry()
+	publishRuntimeMetrics(reg, "test-svc")
+
+	got := map[string]bool{}
+	for _, m := range reg.GetAll() {
+		got[m.Name] = true
+	}
+
+	// The set MonigoCollector.Collect exposes in exporters/prometheus.go.
+	want := []string{
+		"monigo_cpu_usage_percent",
+		"monigo_memory_usage_bytes",
+		"monigo_goroutines_count",
+		"monigo_disk_read_bytes_total",
+		"monigo_disk_write_bytes_total",
+	}
+	for _, name := range want {
+		if !got[name] {
+			t.Errorf("%s is scraped by the Prometheus collector but never pushed", name)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("published %d metrics, the Prometheus collector exposes %d -- "+
+			"the two paths have drifted", len(got), len(want))
+	}
+}
+
+// TestEveryPublishedMetricCarriesTheServiceLabel guards against the ambiguity
+// that appears the moment two services push to one backend.
+func TestEveryPublishedMetricCarriesTheServiceLabel(t *testing.T) {
+	reg := registry.NewRegistry()
+	publishRuntimeMetrics(reg, "svc-a")
+	for _, m := range reg.GetAll() {
+		if m.Labels["service"] != "svc-a" {
+			t.Errorf("%s carries service=%q, expected %q", m.Name, m.Labels["service"], "svc-a")
+		}
+	}
+}
+
+// TestNoExportersMeansNoPipeline: a MoniGo with nothing configured to push
+// should not start a goroutine that collects stats every 30s for no reader.
+func TestNoExportersMeansNoPipeline(t *testing.T) {
+	if p := startExportPipelineWith(nil, "test-svc", time.Second); p != nil {
+		t.Error("a pipeline was started with no exporters configured")
+		p.Stop()
+	}
+	m := &Monigo{ServiceName: "test-svc"}
+	if exps := m.pushExporters(); len(exps) != 0 {
+		t.Errorf("pushExporters() returned %d exporters for an unconfigured MoniGo", len(exps))
+	}
+}
+
+// TestPrometheusIsNotInThePushPipeline: Prometheus is scraped. Pushing to it
+// would double-report and imply a delivery guarantee that does not exist.
+func TestPrometheusIsNotInThePushPipeline(t *testing.T) {
+	m := &Monigo{ServiceName: "test-svc"}
+	for _, e := range m.pushExporters() {
+		if e.Name() == "prometheus" {
+			t.Error("the Prometheus exporter is in the push pipeline; it is scrape-based")
+		}
+	}
+}
+
+// TestStoppingTwiceIsSafe -- Shutdown may run after an explicit Stop, and the
+// signal handler can race a manual call.
+func TestStoppingTwiceIsSafe(t *testing.T) {
+	rec := newRecordingExporter()
+	m := &Monigo{ServiceName: "test-svc"}
+	m.exportPipeline = startExportPipelineWith([]exporter.Exporter{rec}, "test-svc", time.Hour)
+	m.stopExportPipeline()
+	m.stopExportPipeline() // must not panic on a nil pipeline
+}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -14,6 +14,7 @@ type Pipeline struct {
 	registry *registry.Registry
 	exporter exporter.Exporter
 	interval time.Duration
+	collect  func()
 	stopChan chan struct{}
 	stopOnce sync.Once
 	wg       sync.WaitGroup
@@ -28,6 +29,18 @@ func NewPipeline(r *registry.Registry, e exporter.Exporter, interval time.Durati
 	}
 }
 
+// WithCollector sets a function run immediately before each export, to refresh
+// the registry from live stats.
+//
+// It is a hook rather than a second goroutine on its own ticker so that the
+// snapshot an export sends is the one taken moments earlier. Two independent
+// tickers at the same interval drift, and an export would then carry a sample
+// of arbitrary age.
+func (p *Pipeline) WithCollector(collect func()) *Pipeline {
+	p.collect = collect
+	return p
+}
+
 func (p *Pipeline) Start(ctx context.Context) {
 	p.wg.Add(1)
 	go func() {
@@ -38,6 +51,9 @@ func (p *Pipeline) Start(ctx context.Context) {
 		for {
 			select {
 			case <-ticker.C:
+				if p.collect != nil {
+					p.collect()
+				}
 				metrics := p.registry.GetAll()
 				if len(metrics) > 0 {
 					if err := p.exporter.Export(ctx, metrics); err != nil {

--- a/monigo.go
+++ b/monigo.go
@@ -23,6 +23,7 @@ import (
 	"github.com/iyashjayesh/monigo/exporters"
 	"github.com/iyashjayesh/monigo/internal/alerting"
 	"github.com/iyashjayesh/monigo/internal/logger"
+	"github.com/iyashjayesh/monigo/internal/pipeline"
 	"github.com/iyashjayesh/monigo/models"
 	"github.com/iyashjayesh/monigo/timeseries"
 )
@@ -84,7 +85,8 @@ type Monigo struct {
 	AuthFunction        func(*http.Request) bool          `json:"-"`
 
 	// Holds a reference so we can shut down cleanly.
-	otelExporter *exporters.OTelExporter
+	otelExporter   *exporters.OTelExporter
+	exportPipeline *pipeline.Pipeline
 }
 
 // MonigoInt is the interface to start the monigo service
@@ -258,6 +260,10 @@ func (m *Monigo) setup() error {
 		}
 	}
 
+	// Without this the exporters above are constructed and never asked for
+	// anything -- see startExportPipeline.
+	m.startExportPipeline()
+
 	return nil
 }
 
@@ -265,6 +271,9 @@ func (m *Monigo) setup() error {
 func (m *Monigo) Shutdown(ctx context.Context) error {
 	var errs []error
 	runCleanups()
+	// Stop pushing before tearing down what we push into, so an in-flight
+	// export cannot race the provider shutdown.
+	m.stopExportPipeline()
 	if m.otelExporter != nil {
 		if err := m.otelExporter.Shutdown(ctx); err != nil {
 			errs = append(errs, fmt.Errorf("otel shutdown: %w", err))


### PR DESCRIPTION
Closes #78. Unblocks the OTel half of #67.

## `WithOTelEndpoint` has never sent a metric

`Registry`, `Pipeline` and `MultiExporter` were each implemented and each unit-tested. **Nothing constructed any of them.**

| Constructor | Non-test callers |
| --- | --- |
| `registry.NewRegistry()` | 0 |
| `pipeline.NewPipeline()` | 0 |
| `exporter.NewMultiExporter()` | 0 |

`monigo.go:256` built the exporter, logged `OTel exporter initialized`, and then used it for exactly one thing — `Shutdown` at line 268. `Export()` was never called in between. Since instruments are registered lazily *inside* `Export`, none ever existed, so the SDK's 30s `PeriodicReader` collected an empty set forever.

**Before**, against a fake collector — 40 seconds of traffic:

```
t=40s  connections=1  bytes=33
```

33 bytes: HTTP/2 preface (24) plus a SETTINGS frame (9). Zero application data.

**After**, against a real OTLP/gRPC receiver:

```
t=30s  batches=1  distinct metrics=5
  monigo_cpu_usage_percent          10.45
  monigo_memory_usage_bytes         11665063936.00
  monigo_goroutines_count           14.00
  monigo_disk_read_bytes_total      159497199616.00
  monigo_disk_write_bytes_total     81724682240.00
```

## Why nothing caught it

Every piece had a unit test; no test covered the wiring. `TestAConfiguredExporterActuallyReceivesMetrics` now drives a recording exporter through the real path and fails if `Export` is never called — which is exactly what it would have done against `main`.

`TestPushedMetricsMatchTheScrapedOnes` pins the push set to `MonigoCollector.Collect`, so a scrape and a push cannot silently drift into reporting different names.

## Three decisions worth reviewing

**Everything is a gauge, including the two disk `_total`s that Prometheus exposes as counters.** The OTel exporter maps `registry.Counter` onto `Float64Counter` and calls `Add(value)`, while `Registry.IncrementCounter` *already accumulates internally*. A cumulative total through that pair re-adds the whole total every cycle and grows quadratically. A gauge carrying the true cumulative value is the honest reading. Making the counter path safe is separate work — it is currently unreachable, and nothing here publishes a counter.

**The interval is 30s, not `DataPointsSyncFrequency`.** That setting governs flushes to the local time-series store and defaults to 5m; at that spacing the OTel reader would resend an unchanged value ten times before it moved. 30s matches the reader.

**One export runs before the ticker starts.** The exporter's reader runs on an independent clock, so deferring the first `Export` to the first tick left the opening reader cycle with no instruments and shipped an empty batch — real data arrived two cycles out. Measured: first delivery moves from ~60s to ~30s.

## Verification

`go test -race ./...` green across all 12 packages. `go vet` clean. End-to-end against a real OTLP/gRPC receiver, before and after, as above.