### PR TITLE
feat(dashboard): Exporters page, with honest push and pull status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Exporters page.** Prometheus and OTel status, at
+  `GET /monigo/api/v1/exporters` and in the dashboard nav. Push and pull are
+  reported in their own terms rather than flattened into one pass/fail:
+  Prometheus scrapes MoniGo, so it shows when it was last scraped and carries
+  no failure count -- a scrape that fails, fails at the collector and the
+  server never learns of it -- while a push exporter shows last attempt, last
+  success, consecutive failures and the transport error verbatim
+
 ### Fixed
+- **The OTel exporter reported success against an unreachable collector.**
+  `Export` only stored values; the SDK's reader shipped them later on its own
+  clock, so the error never reached the caller and the dashboard would have
+  read "ok" while nothing arrived. Export now flushes and returns the
+  transport's verdict, leaving one clock instead of two
 - **`WithOTelEndpoint` connected to the collector and never sent a metric.**
   `Registry`, `Pipeline` and `MultiExporter` were each implemented and each
   unit-tested, and nothing ever constructed them, so `OTelExporter.Export` was

--- a/api/exporters_handler.go
+++ b/api/exporters_handler.go
@@ -1,0 +1,94 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/iyashjayesh/monigo/exporters"
+	"github.com/iyashjayesh/monigo/internal/exporter"
+)
+
+// exporterView is the wire shape.
+//
+// The fields are spelled out rather than embedding exporter.Health for two
+// reasons. `omitempty` does nothing for a time.Time -- a struct is never
+// "empty" to encoding/json -- so an unset timestamp would serialise as
+// "0001-01-01T00:00:00Z" and the dashboard would faithfully render "last
+// scraped in the year 1". Pointers omit properly.
+//
+// And a pull exporter has no failure count: a scrape that fails, fails at the
+// client and MoniGo never hears about it. Emitting failures:0 there would
+// assert a health signal that does not exist, so those fields are omitted for
+// the pull kind rather than sent as zeros.
+type exporterView struct {
+	Name  string `json:"name"`
+	Kind  string `json:"kind"`
+	State string `json:"state"`
+	Total uint64 `json:"total"`
+
+	LastSuccess *time.Time `json:"last_success,omitempty"`
+
+	// Push only.
+	LastAttempt         *time.Time `json:"last_attempt,omitempty"`
+	ConsecutiveFailures *int       `json:"consecutive_failures,omitempty"`
+	Failures            *uint64    `json:"failures,omitempty"`
+	LastError           string     `json:"last_error,omitempty"`
+}
+
+type exportersResponse struct {
+	Exporters []exporterView `json:"exporters"`
+}
+
+// GetExportersStatus reports the state of every configured exporter.
+//
+// Prometheus is always listed: its collector is registered in this package's
+// init, so the scrape endpoint exists whether or not anyone is scraping it.
+// Push exporters are listed only when one is configured -- an empty push list
+// means nothing is set up to push, which the dashboard shows differently from
+// a configured exporter that is failing.
+func GetExportersStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	views := []exporterView{
+		toView(exporters.NewMonigoCollector().ScrapeHealth()),
+	}
+	for _, h := range exporter.ActiveHealth() {
+		views = append(views, toView(h))
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(exportersResponse{Exporters: views}); err != nil {
+		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+	}
+}
+
+func toView(h exporter.Health) exporterView {
+	v := exporterView{
+		Name:        h.Name,
+		Kind:        h.Kind,
+		State:       h.State(),
+		Total:       h.Total,
+		LastSuccess: nonZero(h.LastSuccess),
+	}
+	if h.Kind == exporter.KindPush {
+		failures := h.Failures
+		consecutive := h.ConsecutiveFailures
+		v.LastAttempt = nonZero(h.LastAttempt)
+		v.ConsecutiveFailures = &consecutive
+		v.Failures = &failures
+		v.LastError = h.LastError
+	}
+	return v
+}
+
+// nonZero returns nil for an unset timestamp so it is omitted entirely.
+func nonZero(t time.Time) *time.Time {
+	if t.IsZero() {
+		return nil
+	}
+	return &t
+}

--- a/api/exporters_handler_test.go
+++ b/api/exporters_handler_test.go
@@ -1,0 +1,114 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/iyashjayesh/monigo/internal/exporter"
+	"github.com/iyashjayesh/monigo/internal/registry"
+)
+
+func getExporters(t *testing.T) (int, string, []map[string]any) {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	GetExportersStatus(rec, httptest.NewRequest(http.MethodGet, "/exporters", nil))
+
+	var body struct {
+		Exporters []map[string]any `json:"exporters"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("response is not valid JSON: %v\n%s", err, rec.Body.String())
+	}
+	return rec.Code, rec.Body.String(), body.Exporters
+}
+
+// Prometheus's collector is registered in this package's init, so the scrape
+// endpoint exists whether or not anyone scrapes it. Omitting it would read as
+// "not available".
+func TestPrometheusIsAlwaysListed(t *testing.T) {
+	exporter.SetActive(nil)
+	code, raw, list := getExporters(t)
+	if code != http.StatusOK {
+		t.Fatalf("status %d: %s", code, raw)
+	}
+	for _, e := range list {
+		if e["name"] == "prometheus" {
+			if e["kind"] != "pull" {
+				t.Errorf("prometheus reported as kind %v, want pull", e["kind"])
+			}
+			return
+		}
+	}
+	t.Errorf("prometheus absent from %s", raw)
+}
+
+// A zero time.Time ignores `omitempty` -- it is a struct, never "empty" to
+// encoding/json -- and would serialise as 0001-01-01T00:00:00Z, which the
+// dashboard would faithfully render as a timestamp in the year 1.
+func TestUnsetTimestampsAreOmittedNotSentAsYearOne(t *testing.T) {
+	exporter.SetActive(nil)
+	_, raw, _ := getExporters(t)
+	if strings.Contains(raw, "0001-01-01") {
+		t.Errorf("a zero timestamp reached the wire: %s", raw)
+	}
+}
+
+// A scrape that fails, fails at the collector; MoniGo never hears about it.
+// Emitting failures:0 would assert a health signal that does not exist.
+func TestPullExportersCarryNoFailureFields(t *testing.T) {
+	exporter.SetActive(nil)
+	_, raw, list := getExporters(t)
+	for _, e := range list {
+		if e["kind"] != "pull" {
+			continue
+		}
+		for _, pushOnly := range []string{"failures", "consecutive_failures", "last_attempt", "last_error"} {
+			if _, present := e[pushOnly]; present {
+				t.Errorf("pull exporter %v carries push-only field %q: %s",
+					e["name"], pushOnly, raw)
+			}
+		}
+	}
+}
+
+func TestPushExporterReportsItsFailure(t *testing.T) {
+	m := exporter.NewMultiExporter(failingExporter{})
+	_ = m.Export(t.Context(), nil)
+	exporter.SetActive(m)
+	defer exporter.SetActive(nil)
+
+	_, raw, list := getExporters(t)
+	for _, e := range list {
+		if e["name"] != "boom" {
+			continue
+		}
+		if e["state"] != exporter.StateFailing {
+			t.Errorf("state = %v, want %q", e["state"], exporter.StateFailing)
+		}
+		if !strings.Contains(raw, "collector unreachable") {
+			t.Errorf("the error text never reached the client: %s", raw)
+		}
+		return
+	}
+	t.Errorf("the push exporter is absent from %s", raw)
+}
+
+func TestNonGETIsRejected(t *testing.T) {
+	rec := httptest.NewRecorder()
+	GetExportersStatus(rec, httptest.NewRequest(http.MethodPost, "/exporters", nil))
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("POST returned %d, want 405", rec.Code)
+	}
+}
+
+type failingExporter struct{}
+
+func (failingExporter) Name() string { return "boom" }
+func (failingExporter) Export(_ context.Context, _ []*registry.MetricValue) error {
+	return errors.New("collector unreachable")
+}

--- a/export_pipeline.go
+++ b/export_pipeline.go
@@ -56,6 +56,7 @@ func startExportPipelineWith(exps []exporter.Exporter, serviceName string, inter
 
 	reg := registry.NewRegistry()
 	multi := exporter.NewMultiExporter(exps...)
+	exporter.SetActive(multi)
 	p := pipeline.NewPipeline(reg, multi, interval).
 		WithCollector(func() { publishRuntimeMetrics(reg, serviceName) })
 
@@ -89,6 +90,7 @@ func (m *Monigo) stopExportPipeline() {
 	if m.exportPipeline != nil {
 		m.exportPipeline.Stop()
 		m.exportPipeline = nil
+		exporter.SetActive(nil)
 	}
 }
 

--- a/exporters/otel.go
+++ b/exporters/otel.go
@@ -60,8 +60,18 @@ func NewOTelExporter(ctx context.Context, cfg OTelConfig) (*OTelExporter, error)
 		return nil, err
 	}
 
+	// The reader's own interval is set far out because Export drives the push
+	// itself via ForceFlush.
+	//
+	// With a short interval there are two clocks: the pipeline calling Export
+	// and the reader shipping batches, each unaware of the other. Export would
+	// return nil the instant it stored a value and the real delivery -- and
+	// any error from it -- happened later on the reader's clock, out of reach.
+	// That made a dead collector indistinguishable from a healthy one: the
+	// dashboard reported "ok" while nothing arrived. One clock, and Export
+	// returns the transport's actual verdict.
 	provider := metric.NewMeterProvider(
-		metric.WithReader(metric.NewPeriodicReader(exporter, metric.WithInterval(30*time.Second))),
+		metric.WithReader(metric.NewPeriodicReader(exporter, metric.WithInterval(24*time.Hour))),
 	)
 	meter := provider.Meter("monigo")
 
@@ -91,7 +101,14 @@ func (o *OTelExporter) Export(ctx context.Context, metrics []*registry.MetricVal
 			logger.Log.Warn("histogram export not yet implemented", "metric", m.Name)
 		}
 	}
-	return firstErr
+	if firstErr != nil {
+		return firstErr
+	}
+
+	// Push now and report what the transport says. Without this the values sit
+	// in the SDK until the reader's next cycle, and Export would report
+	// success for a collector that is unreachable.
+	return o.provider.ForceFlush(ctx)
 }
 
 func (o *OTelExporter) exportGauge(m *registry.MetricValue) error {
@@ -175,4 +192,3 @@ func labelsToAttributes(labels map[string]string) []attribute.KeyValue {
 	}
 	return attrs
 }
-

--- a/exporters/prometheus.go
+++ b/exporters/prometheus.go
@@ -3,13 +3,23 @@ package exporters
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/iyashjayesh/monigo/core"
+	"github.com/iyashjayesh/monigo/internal/exporter"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 // MonigoCollector implements the prometheus.Collector interface.
+//
+// Prometheus pulls: MoniGo never exports to it, so the only honest status is
+// when it was last scraped and how often. scrapeMu guards those counters,
+// which Collect writes from whichever goroutine the registry scrapes on.
 type MonigoCollector struct {
+	scrapeMu    sync.Mutex
+	scrapeCount uint64
+	lastScrape  time.Time
+
 	cpuUsage    *prometheus.Desc
 	memoryUsage *prometheus.Desc
 	goroutines  *prometheus.Desc
@@ -69,6 +79,11 @@ func (c *MonigoCollector) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect is called by the Prometheus registry when collecting metrics.
 func (c *MonigoCollector) Collect(ch chan<- prometheus.Metric) {
+	c.scrapeMu.Lock()
+	c.scrapeCount++
+	c.lastScrape = time.Now()
+	c.scrapeMu.Unlock()
+
 	stats := core.GetServiceStats(context.Background())
 
 	// CPU Load - use raw float64 values directly, no string parsing
@@ -103,4 +118,21 @@ func (c *MonigoCollector) Collect(ch chan<- prometheus.Metric) {
 		prometheus.CounterValue,
 		float64(stats.DiskIO.WriteBytes),
 	)
+}
+
+// ScrapeHealth reports how the Prometheus endpoint is being used.
+//
+// There is no failure counter: a scrape that fails, fails at the client, and
+// MoniGo never learns of it. Reporting a fabricated zero would imply a health
+// signal that does not exist, so the pull kind carries no failure fields and
+// the dashboard renders it as "scraped Ns ago" rather than a pass/fail verdict.
+func (c *MonigoCollector) ScrapeHealth() exporter.Health {
+	c.scrapeMu.Lock()
+	defer c.scrapeMu.Unlock()
+	return exporter.Health{
+		Name:        "prometheus",
+		Kind:        exporter.KindPull,
+		LastSuccess: c.lastScrape,
+		Total:       c.scrapeCount,
+	}
 }

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -3,6 +3,7 @@ package exporter
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/iyashjayesh/monigo/internal/logger"
 	"github.com/iyashjayesh/monigo/internal/registry"
@@ -15,17 +16,35 @@ type Exporter interface {
 
 type MultiExporter struct {
 	exporters []Exporter
+	health    *healthTracker
 }
 
 func NewMultiExporter(exporters ...Exporter) *MultiExporter {
-	return &MultiExporter{exporters: exporters}
+	m := &MultiExporter{exporters: exporters, health: newHealthTracker()}
+	// Seed a record per exporter so a configured-but-never-run exporter is
+	// reported as "never" rather than being absent from the dashboard, which
+	// would be indistinguishable from not being configured at all.
+	for _, e := range exporters {
+		m.health.mu.Lock()
+		m.health.get(e.Name(), KindPush)
+		m.health.mu.Unlock()
+	}
+	return m
+}
+
+// Health returns the current status of every push exporter.
+func (m *MultiExporter) Health() []Health {
+	return m.health.snapshot()
 }
 
 // Export fans out to all exporters, collecting errors without short-circuiting.
 func (m *MultiExporter) Export(ctx context.Context, metrics []*registry.MetricValue) error {
 	var errs []error
 	for _, e := range m.exporters {
-		if err := e.Export(ctx, metrics); err != nil {
+		at := time.Now()
+		err := e.Export(ctx, metrics)
+		m.health.record(e.Name(), at, err)
+		if err != nil {
 			logger.Log.Error("exporter failed", "name", e.Name(), "error", err)
 			errs = append(errs, err)
 		}

--- a/internal/exporter/status.go
+++ b/internal/exporter/status.go
@@ -1,0 +1,134 @@
+package exporter
+
+import (
+	"sync"
+	"time"
+)
+
+// Health describes what an exporter is doing, for display on the dashboard.
+//
+// Push and pull exporters do not share a vocabulary, and flattening them into
+// one "OK / FAIL" would misreport half of them. MoniGo never exports to
+// Prometheus -- Prometheus scrapes it -- so "last export succeeded" is
+// meaningless there; the honest reading is when it was last scraped. Kind says
+// which set of fields is meaningful.
+type Health struct {
+	Name string `json:"name"`
+	Kind string `json:"kind"` // KindPush or KindPull
+
+	// Push only. LastAttempt differs from LastSuccess while an exporter is
+	// failing, which is what makes "retrying" distinguishable from "idle".
+	LastAttempt         time.Time `json:"last_attempt,omitempty"`
+	ConsecutiveFailures int       `json:"consecutive_failures"`
+	LastError           string    `json:"last_error,omitempty"`
+
+	// Both kinds. For a pull exporter LastSuccess is the last scrape.
+	LastSuccess time.Time `json:"last_success,omitempty"`
+	Total       uint64    `json:"total"`
+	Failures    uint64    `json:"failures"`
+}
+
+const (
+	KindPush = "push"
+	KindPull = "pull"
+)
+
+// State is the verdict a dashboard shows. Derived rather than stored, so it
+// cannot fall out of step with the counters behind it.
+const (
+	StateNever    = "never"    // configured, nothing has happened yet
+	StateOK       = "ok"       // last attempt succeeded
+	StateRetrying = "retrying" // failing now, has succeeded before
+	StateFailing  = "failing"  // failing and has never succeeded
+)
+
+// State reports the exporter's current condition.
+func (h Health) State() string {
+	if h.ConsecutiveFailures > 0 {
+		if h.LastSuccess.IsZero() {
+			return StateFailing
+		}
+		return StateRetrying
+	}
+	if h.Total == 0 || h.LastSuccess.IsZero() {
+		return StateNever
+	}
+	return StateOK
+}
+
+// healthTracker records outcomes per exporter name.
+type healthTracker struct {
+	mu sync.Mutex
+	by map[string]*Health
+}
+
+func newHealthTracker() *healthTracker {
+	return &healthTracker{by: make(map[string]*Health)}
+}
+
+func (t *healthTracker) get(name, kind string) *Health {
+	h, ok := t.by[name]
+	if !ok {
+		h = &Health{Name: name, Kind: kind}
+		t.by[name] = h
+	}
+	return h
+}
+
+// record notes the outcome of one push attempt.
+func (t *healthTracker) record(name string, at time.Time, err error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	h := t.get(name, KindPush)
+	h.LastAttempt = at
+	h.Total++
+	if err != nil {
+		h.Failures++
+		h.ConsecutiveFailures++
+		h.LastError = err.Error()
+		return
+	}
+	h.LastSuccess = at
+	h.ConsecutiveFailures = 0
+	h.LastError = ""
+}
+
+func (t *healthTracker) snapshot() []Health {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	out := make([]Health, 0, len(t.by))
+	for _, h := range t.by {
+		out = append(out, *h)
+	}
+	return out
+}
+
+// The active MultiExporter, published so the API layer can report exporter
+// health without importing the root package (which imports api, and would
+// cycle). Set when the export pipeline starts; nil when nothing pushes.
+var (
+	activeMu sync.RWMutex
+	active   *MultiExporter
+)
+
+// SetActive publishes the running MultiExporter for status reporting.
+// Passing nil clears it, which is what a stopped pipeline should do.
+func SetActive(m *MultiExporter) {
+	activeMu.Lock()
+	defer activeMu.Unlock()
+	active = m
+}
+
+// ActiveHealth returns the health of the running push exporters, or nil when
+// no pipeline is running. Nil means "nothing configured to push", which the
+// dashboard reports differently from "configured and failing".
+func ActiveHealth() []Health {
+	activeMu.RLock()
+	defer activeMu.RUnlock()
+	if active == nil {
+		return nil
+	}
+	return active.Health()
+}

--- a/internal/exporter/status_test.go
+++ b/internal/exporter/status_test.go
@@ -1,0 +1,105 @@
+package exporter
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/iyashjayesh/monigo/internal/registry"
+)
+
+func TestStateReflectsWhatHasActuallyHappened(t *testing.T) {
+	past := time.Now().Add(-time.Minute)
+
+	cases := []struct {
+		name string
+		h    Health
+		want string
+	}{
+		{"configured, nothing yet", Health{Kind: KindPush}, StateNever},
+		{"one success", Health{Kind: KindPush, Total: 1, LastSuccess: past}, StateOK},
+		{
+			// Failing but has succeeded before: recoverable, not broken.
+			"failing after a success",
+			Health{Kind: KindPush, Total: 3, LastSuccess: past, ConsecutiveFailures: 2},
+			StateRetrying,
+		},
+		{
+			// Never once succeeded: usually a wrong endpoint or no route,
+			// which is a different problem from an intermittent one.
+			"never succeeded",
+			Health{Kind: KindPush, Total: 3, ConsecutiveFailures: 3},
+			StateFailing,
+		},
+		{"scraped once", Health{Kind: KindPull, Total: 1, LastSuccess: past}, StateOK},
+		{"never scraped", Health{Kind: KindPull}, StateNever},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.h.State(); got != c.want {
+				t.Errorf("State() = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestASuccessClearsTheFailureStreakButNotTheTotal(t *testing.T) {
+	tr := newHealthTracker()
+	boom := errors.New("connection refused")
+
+	tr.record("otel", time.Now(), boom)
+	tr.record("otel", time.Now(), boom)
+	h := tr.snapshot()[0]
+	if h.ConsecutiveFailures != 2 || h.Failures != 2 || h.Total != 2 {
+		t.Fatalf("after two failures: consecutive=%d failures=%d total=%d",
+			h.ConsecutiveFailures, h.Failures, h.Total)
+	}
+	if h.State() != StateFailing {
+		t.Errorf("state = %q, want %q", h.State(), StateFailing)
+	}
+
+	tr.record("otel", time.Now(), nil)
+	h = tr.snapshot()[0]
+	if h.ConsecutiveFailures != 0 {
+		t.Errorf("a success left a streak of %d", h.ConsecutiveFailures)
+	}
+	if h.Failures != 2 {
+		t.Errorf("a success erased history: failures=%d, want 2", h.Failures)
+	}
+	if h.LastError != "" {
+		t.Errorf("a success left the stale error %q", h.LastError)
+	}
+	if h.State() != StateOK {
+		t.Errorf("state = %q, want %q", h.State(), StateOK)
+	}
+}
+
+// A configured exporter that has never run must still appear. Absent from the
+// list is indistinguishable from not configured, which is the one thing an
+// operator checking this page needs to tell apart.
+func TestAConfiguredExporterAppearsBeforeItHasEverRun(t *testing.T) {
+	m := NewMultiExporter(stubExporter{name: "otel-otlp"})
+	got := m.Health()
+	if len(got) != 1 {
+		t.Fatalf("Health() returned %d entries, want 1", len(got))
+	}
+	if got[0].Name != "otel-otlp" || got[0].State() != StateNever {
+		t.Errorf("got %q/%q, want otel-otlp/never", got[0].Name, got[0].State())
+	}
+}
+
+func TestActiveHealthIsNilWhenNothingIsRunning(t *testing.T) {
+	SetActive(nil)
+	if got := ActiveHealth(); got != nil {
+		t.Errorf("ActiveHealth() = %v with no pipeline, want nil", got)
+	}
+}
+
+type stubExporter struct {
+	name string
+	err  error
+}
+
+func (s stubExporter) Name() string                                              { return s.name }
+func (s stubExporter) Export(_ context.Context, _ []*registry.MetricValue) error { return s.err }

--- a/routes.go
+++ b/routes.go
@@ -47,6 +47,7 @@ func apiRoutes() []apiRoute {
 		{"/function", api.GetFunctionTraceDetails},
 		{"/function-details", api.ViewFunctionMetrics},
 		{"/reports", api.GetReportData},
+		{"/exporters", api.GetExportersStatus},
 	}
 }
 

--- a/static/css/monigo-styles.css
+++ b/static/css/monigo-styles.css
@@ -1079,3 +1079,101 @@
 #mg-runtime-load-failed[hidden] {
     display: none;
 }
+
+/* ---------------------------------------------------------------- exporters
+   Push and pull exporters do not share a vocabulary, so the card renders a
+   different set of facts for each rather than forcing both into one shape. */
+
+.mg-exp-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 14px;
+}
+
+.mg-exp-card {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 16px;
+}
+
+.mg-exp-head {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+}
+
+.mg-exp-name {
+    font-weight: 600;
+    font-size: var(--t-body);
+}
+
+.mg-exp-kind {
+    font: 500 var(--t-micro) var(--mono);
+    letter-spacing: .04em;
+    text-transform: uppercase;
+    color: var(--ink-subtle);
+    border: 1px solid var(--hairline);
+    border-radius: var(--r-sm);
+    padding: 1px 6px;
+}
+
+.mg-exp-state {
+    margin-left: auto;
+    font: 600 var(--t-micro) var(--mono);
+    letter-spacing: .05em;
+    text-transform: uppercase;
+    border-radius: var(--r-sm);
+    padding: 2px 8px;
+}
+
+.mg-exp-state.is-ok       { color: var(--ok);   background: var(--ok-tint); }
+.mg-exp-state.is-warn     { color: var(--warn); background: var(--warn-tint); }
+.mg-exp-state.is-bad      { color: var(--bad);  background: var(--crit-tint); }
+.mg-exp-state.is-unknown  { color: var(--ink-subtle); background: var(--unknown-tint); }
+
+.mg-exp-facts {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(88px, 1fr));
+    gap: 10px 14px;
+}
+
+.mg-exp-fact {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    min-width: 0;
+}
+
+.mg-exp-factlabel {
+    font: 500 var(--t-micro) var(--mono);
+    letter-spacing: .05em;
+    text-transform: uppercase;
+    color: var(--ink-subtle);
+}
+
+.mg-exp-factvalue {
+    font: 600 var(--t-body-s) var(--mono);
+    color: var(--ink);
+    overflow-wrap: anywhere;
+}
+
+.mg-exp-factvalue.is-bad { color: var(--bad); }
+
+/* The error is the widest thing on the card and the least predictable, so it
+   gets its own full-width row and wraps rather than truncating -- a clipped
+   gRPC error is usually clipped exactly where the cause was. */
+.mg-exp-error {
+    font: 400 var(--t-code) / var(--t-code-lh) var(--mono);
+    color: var(--bad);
+    background: var(--crit-tint);
+    border-radius: var(--r-sm);
+    padding: 8px 10px;
+    overflow-wrap: anywhere;
+}
+
+.mg-exp-note {
+    font: 400 var(--t-micro) / var(--t-micro-lh) var(--sans);
+    color: var(--ink-subtle);
+    text-wrap: pretty;
+}

--- a/static/exporters.html
+++ b/static/exporters.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>MoniGo — Reports</title>
+    <title>MoniGo — Exporters</title>
     <link rel="icon" href="./assets/favicon.ico">
     <link rel="stylesheet" href="./css/monigo-design.css">
     <link rel="stylesheet" href="./css/monigo-styles.css">
@@ -60,11 +60,11 @@
         <span>Goroutines</span>
         <span class="mg-badge" id="mg-count-goroutines"></span>
       </a>
-      <a href="./reports.html" class="is-active">
+      <a href="./reports.html">
         <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M3.2 2.2h6l3.6 3.6v8a.6.6 0 0 1-.6.6H3.2a.6.6 0 0 1-.6-.6V2.8a.6.6 0 0 1 .6-.6z"></path><path d="M9 2.4V6h3.6M5.2 9.4h5.6M5.2 11.6h3.4"></path></svg>
         <span>Reports</span>
       </a>
-      <a href="./exporters.html">
+      <a href="./exporters.html" class="is-active">
         <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M8 1.8v5.4M8 7.2 4.4 9.6M8 7.2l3.6 2.4"></path><circle cx="8" cy="1.8" r="1.3"></circle><circle cx="4.4" cy="10.4" r="1.3"></circle><circle cx="11.6" cy="10.4" r="1.3"></circle><path d="M2.4 13.6h11.2"></path></svg>
         <span>Exporters</span>
       </a>
@@ -85,27 +85,9 @@
               aria-label="Toggle navigation" aria-expanded="false">
         <svg class="mg-icon" aria-hidden="true"><use href="#i-menu"></use></svg>
       </button>
-      <span class="mg-top__title">Reports</span>
+      <span class="mg-top__title">Exporters</span>
       <span class="mg-top__sub" id="mg-asof"></span>
       <div class="mg-top__right">
-    <!-- These must match RANGE_MINUTES in reports-view.js. They did not: the
-         shell rebuild gave this page the Overview's group, leaving a 5m button
-         the JS had no entry for -- clicking it produced an Invalid Date and
-         threw a RangeError out of the handler, so the page silently stopped --
-         and a 6h entry with no button. No 5m: at the default 5m sync interval
-         that window can never hold two samples. -->
-    <div class="mg-range" id="mg-range" role="group" aria-label="Report window">
-      <button type="button" class="mg-range-seg" data-range="15m" aria-pressed="false">15m</button>
-      <button type="button" class="mg-range-seg is-active" data-range="1h" aria-pressed="true">1h</button>
-      <button type="button" class="mg-range-seg" data-range="6h" aria-pressed="false">6h</button>
-      <button type="button" class="mg-range-seg" data-range="24h" aria-pressed="false">24h</button>
-    </div>
-        <!-- No LIVE control. A report answers a question about a window you
-             chose; re-fetching every fifteen seconds would move the ground
-             under whoever is reading it. The pill that sat here was
-             permanently green and wired to nothing, asserting a freshness the
-             page never had. The as-of stamp says when it was actually
-             fetched. -->
         <button type="button" class="mg-iconbtn" id="mg-theme-toggle" title="Toggle theme"
                 aria-label="Toggle theme">
           <svg class="mg-icon" aria-hidden="true"><use href="#i-moon" id="mg-theme-icon"></use></svg>
@@ -124,59 +106,19 @@
     <main class="mg-content" id="mg-content">
       <div class="mg-stack">
 
+  <!-- Prometheus is always listed: its collector is registered at package init,
+       so the scrape endpoint exists whether or not anything scrapes it. Push
+       exporters appear only once configured. -->
+  <section class="mg-exp-grid" id="mg-exp-grid"></section>
+  <p class="mg-fn-empty" id="mg-exp-empty" hidden></p>
 
-  <!-- Window / topic / export. RESOLUTION and Generate PDF are omitted:
-       storage has no downsampling, and there is no PDF renderer that would
-       work on an airgapped host. -->
-  <div class="mg-card mg-rep-toolbar">
-    <div class="mg-rep-fact">
-      <span class="mg-eyebrow">WINDOW</span>
-      <span class="mg-rep-value" id="mg-rep-window">—</span>
-    </div>
-    <div class="mg-rep-sep" aria-hidden="true"></div>
-    <label class="mg-rep-fact">
-      <span class="mg-eyebrow">TOPIC</span>
-      <select id="mg-rep-topic" class="mg-fn-select" aria-label="Report topic">
-        <option value="LoadStatistics">Load statistics</option>
-        <option value="CPUStatistics">CPU statistics</option>
-        <option value="MemoryStatistics">Memory statistics</option>
-        <option value="MemoryProfile">Memory profile</option>
-        <option value="NetworkIO">Network I/O</option>
-        <option value="OverallHealth">Overall health</option>
-      </select>
-    </label>
-    <div class="mg-rep-sep" aria-hidden="true"></div>
-    <div class="mg-rep-fact">
-      <span class="mg-eyebrow">SAMPLES</span>
-      <span class="mg-rep-value" id="mg-rep-samples">—</span>
-    </div>
-    <div class="mg-rep-actions">
-      <button type="button" class="mg-fn-export" id="mg-rep-json">JSON</button>
-      <button type="button" class="mg-fn-export" id="mg-rep-csv">CSV</button>
-    </div>
-  </div>
-
-  <section class="mg-rep-grid" id="mg-rep-grid"></section>
-  <p class="mg-fn-empty" id="mg-rep-empty" hidden></p>
-
-  <template id="mg-rep-card-tpl">
-    <article class="mg-card mg-rep-card">
-      <span class="mg-rep-title"></span>
-      <svg class="mg-rep-spark" viewBox="0 0 280 90" preserveAspectRatio="none"
-           role="img" aria-hidden="true">
-        <path class="mg-rep-area"></path>
-        <path class="mg-rep-line"></path>
-      </svg>
-      <span class="mg-rep-stats"></span>
-    </article>
-  </template>
       </div>
     </main>
   </div>
 </div>
 
     <script src="./js/common.js" defer></script>
-    <script src="./js/reports-view.js" defer></script>
+    <script src="./js/exporters-view.js" defer></script>
 </body>
 
 </html>

--- a/static/function-metrics.html
+++ b/static/function-metrics.html
@@ -64,6 +64,10 @@
         <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M3.2 2.2h6l3.6 3.6v8a.6.6 0 0 1-.6.6H3.2a.6.6 0 0 1-.6-.6V2.8a.6.6 0 0 1 .6-.6z"></path><path d="M9 2.4V6h3.6M5.2 9.4h5.6M5.2 11.6h3.4"></path></svg>
         <span>Reports</span>
       </a>
+      <a href="./exporters.html">
+        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M8 1.8v5.4M8 7.2 4.4 9.6M8 7.2l3.6 2.4"></path><circle cx="8" cy="1.8" r="1.3"></circle><circle cx="4.4" cy="10.4" r="1.3"></circle><circle cx="11.6" cy="10.4" r="1.3"></circle><path d="M2.4 13.6h11.2"></path></svg>
+        <span>Exporters</span>
+      </a>
     </div>
 
     <div class="mg-rail__foot">

--- a/static/go-routines-stats.html
+++ b/static/go-routines-stats.html
@@ -64,6 +64,10 @@
         <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M3.2 2.2h6l3.6 3.6v8a.6.6 0 0 1-.6.6H3.2a.6.6 0 0 1-.6-.6V2.8a.6.6 0 0 1 .6-.6z"></path><path d="M9 2.4V6h3.6M5.2 9.4h5.6M5.2 11.6h3.4"></path></svg>
         <span>Reports</span>
       </a>
+      <a href="./exporters.html">
+        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M8 1.8v5.4M8 7.2 4.4 9.6M8 7.2l3.6 2.4"></path><circle cx="8" cy="1.8" r="1.3"></circle><circle cx="4.4" cy="10.4" r="1.3"></circle><circle cx="11.6" cy="10.4" r="1.3"></circle><path d="M2.4 13.6h11.2"></path></svg>
+        <span>Exporters</span>
+      </a>
     </div>
 
     <div class="mg-rail__foot">

--- a/static/index.html
+++ b/static/index.html
@@ -64,6 +64,10 @@
         <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M3.2 2.2h6l3.6 3.6v8a.6.6 0 0 1-.6.6H3.2a.6.6 0 0 1-.6-.6V2.8a.6.6 0 0 1 .6-.6z"></path><path d="M9 2.4V6h3.6M5.2 9.4h5.6M5.2 11.6h3.4"></path></svg>
         <span>Reports</span>
       </a>
+      <a href="./exporters.html">
+        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M8 1.8v5.4M8 7.2 4.4 9.6M8 7.2l3.6 2.4"></path><circle cx="8" cy="1.8" r="1.3"></circle><circle cx="4.4" cy="10.4" r="1.3"></circle><circle cx="11.6" cy="10.4" r="1.3"></circle><path d="M2.4 13.6h11.2"></path></svg>
+        <span>Exporters</span>
+      </a>
     </div>
 
     <div class="mg-rail__foot">

--- a/static/js/exporters-view.js
+++ b/static/js/exporters-view.js
@@ -1,0 +1,159 @@
+/*
+ * Exporters page renderer.
+ *
+ * Push and pull exporters are shown with different facts, because they do not
+ * mean the same things. MoniGo pushes to OTel, so last-attempt, consecutive
+ * failures and the last error are all meaningful there. Prometheus scrapes
+ * MoniGo, so "last export succeeded" is meaningless: the honest reading is
+ * when it was last scraped, and there is no failure count at all -- a scrape
+ * that fails, fails at the client and the server never learns of it. Showing
+ * "0 failures" for Prometheus would assert a health signal that does not
+ * exist.
+ */
+document.addEventListener('DOMContentLoaded', () => {
+    'use strict';
+
+    function getApiKey() {
+        const params = new URLSearchParams(window.location.search);
+        return params.get('api_key') || window.MONIGO_API_KEY || null;
+    }
+
+    function authenticatedFetch(url, options = {}) {
+        const key = getApiKey();
+        if (!key) {
+            return fetch(url, options);
+        }
+        const headers = Object.assign({}, options.headers, { 'X-API-Key': key });
+        return fetch(url, Object.assign({}, options, { headers }));
+    }
+
+    function esc(s) {
+        return String(s == null ? '' : s).replace(/[&<>"']/g, c => ({
+            '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+        }[c]));
+    }
+
+    /* Relative time. Anything older than a day is given as a date: "31d ago"
+       reads as a measurement, and at that age it is really just "stale". */
+    function ago(iso) {
+        if (!iso) { return 'never'; }
+        const then = new Date(iso);
+        if (isNaN(then)) { return 'unknown'; }
+        const secs = Math.floor((Date.now() - then.getTime()) / 1000);
+        if (secs < 0) { return 'just now'; }
+        if (secs < 60) { return secs + 's ago'; }
+        if (secs < 3600) { return Math.floor(secs / 60) + 'm ago'; }
+        if (secs < 86400) { return Math.floor(secs / 3600) + 'h ago'; }
+        return then.toISOString().slice(0, 10);
+    }
+
+    const STATE_TONE = {
+        ok: 'is-ok',
+        retrying: 'is-warn',
+        failing: 'is-bad',
+        never: 'is-unknown'
+    };
+
+    /* The word on the pill. "never" is spelled out per kind, because "never"
+       alone reads as a fault, and for a pull exporter that nobody has scraped
+       yet it is simply the starting state. */
+    function stateLabel(e) {
+        if (e.state !== 'never') { return e.state; }
+        return e.kind === 'pull' ? 'not scraped' : 'idle';
+    }
+
+    function fact(label, value, bad) {
+        return '<div class="mg-exp-fact">' +
+            '<span class="mg-exp-factlabel">' + esc(label) + '</span>' +
+            '<span class="mg-exp-factvalue' + (bad ? ' is-bad' : '') + '">' +
+            esc(value) + '</span></div>';
+    }
+
+    function card(e) {
+        const tone = STATE_TONE[e.state] || 'is-unknown';
+        let facts = '';
+
+        if (e.kind === 'pull') {
+            facts += fact('Last scrape', ago(e.last_success));
+            facts += fact('Scrapes', e.total || 0);
+        } else {
+            facts += fact('Last success', ago(e.last_success));
+            facts += fact('Last attempt', ago(e.last_attempt));
+            // "Attempts", not "Exports": total counts every try, so a card
+            // reading "Exports 1 / Failures 1" would otherwise claim one
+            // export happened when none did.
+            facts += fact('Attempts', e.total || 0);
+            facts += fact('Failures', e.failures || 0, (e.failures || 0) > 0);
+            if ((e.consecutive_failures || 0) > 0) {
+                facts += fact('Consecutive', e.consecutive_failures, true);
+            }
+        }
+
+        let note = '';
+        if (e.kind === 'pull') {
+            note = '<span class="mg-exp-note">Prometheus scrapes MoniGo at ' +
+                '<code>/metrics</code>. A failed scrape fails at the collector, ' +
+                'so no error is visible from here.</span>';
+        } else if (e.state === 'never') {
+            note = '<span class="mg-exp-note">Configured, nothing sent yet. ' +
+                'The first export runs at startup, then once per interval.</span>';
+        }
+
+        return '<article class="mg-card mg-exp-card">' +
+            '<div class="mg-exp-head">' +
+            '<span class="mg-exp-name">' + esc(e.name) + '</span>' +
+            '<span class="mg-exp-kind">' + esc(e.kind) + '</span>' +
+            '<span class="mg-exp-state ' + tone + '">' + esc(stateLabel(e)) + '</span>' +
+            '</div>' +
+            '<div class="mg-exp-facts">' + facts + '</div>' +
+            (e.last_error ? '<div class="mg-exp-error">' + esc(e.last_error) + '</div>' : '') +
+            note +
+            '</article>';
+    }
+
+    const grid = document.getElementById('mg-exp-grid');
+    const empty = document.getElementById('mg-exp-empty');
+
+    function render(data) {
+        const list = (data && data.exporters) || [];
+        if (!list.length) {
+            grid.innerHTML = '';
+            empty.hidden = false;
+            empty.textContent = 'No exporters reported.';
+            return;
+        }
+        empty.hidden = true;
+        grid.innerHTML = list.map(card).join('');
+
+        /* Absence of a push exporter is a configuration fact, not a failure,
+           and saying so is more useful than an empty area the reader has to
+           interpret. */
+        if (!list.some(e => e.kind === 'push')) {
+            empty.hidden = false;
+            empty.textContent =
+                'No push exporter configured. Add one with WithOTelEndpoint("host:4317").';
+        }
+    }
+
+    function load() {
+        return authenticatedFetch('/monigo/api/v1/exporters')
+            .then(r => {
+                if (!r.ok) { throw new Error('HTTP ' + r.status); }
+                return r.json();
+            })
+            .then(data => {
+                render(data);
+                if (window.MG && MG.markOk) { MG.markOk(); }
+            })
+            .catch(() => {
+                if (window.MG && MG.markFail) { MG.markFail(); }
+            });
+    }
+
+    if (window.MG && MG.Poll) {
+        MG.Poll.start(load, 10000);
+    } else {
+        load();
+        setInterval(load, 10000);
+    }
+});


### PR DESCRIPTION
Closes #67 — the last entry under "Known gaps" in the changelog.


## Push and pull are not the same thing

The canvas showed Prometheus as `SCRAPED` and OTel as `RETRYING`, and that distinction is load-bearing. MoniGo *pushes* to OTel, so last attempt, last success, consecutive failures and the transport error are all meaningful. Prometheus *scrapes* MoniGo, so "last export succeeded" means nothing there.

More importantly, **a pull exporter has no failure count**: a scrape that fails, fails at the collector, and the server never hears about it. Sending `failures: 0` for Prometheus would assert a health signal that does not exist, so the pull kind carries no failure fields at all rather than zeros.

A configured exporter that has never run is listed as `idle`, not omitted — absent from the page is indistinguishable from not configured, which is the one distinction someone checking this page actually needs.

## The OTel exporter had to start telling the truth first

Building the page surfaced this. `Export` only stored gauge values and returned `nil`; the SDK's reader shipped them later on an independent clock, so the error never reached the caller. **Pointed at a closed port, the exporter reported `ok`.**

A status page that says "ok" while nothing is delivered is worse than no page at all, so `Export` now flushes and returns the transport's actual verdict, and the reader's own interval moves out of the way — one clock instead of two. Against a closed port:

```json
{
  "name": "otel-otlp", "kind": "push", "state": "failing",
  "consecutive_failures": 1, "failures": 1,
  "last_error": "failed to upload metrics: ... dial tcp 127.0.0.1:65533: connect: connection refused"
}
```

## Two details the wire format forced

**A zero `time.Time` ignores `omitempty`** — a struct is never "empty" to `encoding/json` — so unset timestamps serialised as `0001-01-01T00:00:00Z` and the page would have rendered "last scraped" in the year 1. The view uses `*time.Time`. `TestUnsetTimestampsAreOmittedNotSentAsYearOne` holds it.

**The push card counts attempts, not exports.** `total` increments on every try, so labelling it "Exports" produced a card reading `Exports 1 / Failures 1` where no export had succeeded. Caught by looking at the rendered page, not the JSON.

## Free coverage from #74

The new route needed **one line** in `apiRoutes()`, and `TestEveryRouteIsReachableFromEveryRouter` immediately covered it across all five registration styles — the first new endpoint since the route table landed, and it cost nothing to reach every router.

## Verification

`go test -race ./...` green across all 12 packages. `go vet` clean, all dashboard JS parses. Verified in the browser in **both themes** against a live service with a deliberately unreachable OTel endpoint, watching the counters increment and the state stay `failing` with the error in full.