### PR TITLE
fix(core): render pprof reports in-process, without the Go toolchain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Profiling required the Go toolchain at runtime, so it was dead in
+  production.** The profile view shelled out to `go tool pprof`, and on any
+  distroless, scratch or alpine image -- nearly every production deployment of
+  a Go service -- `go` is not on `PATH`, so the dashboard showed
+  `Error: 'go' command not found` where the report should be. It also spawned a
+  subprocess per HTTP request. Profiles written by `runtime/pprof` are fully
+  symbolized, so they are now parsed in-process with
+  `github.com/google/pprof/profile`, which needs no binary, no source tree and
+  no toolchain. `os/exec` is gone from that path entirely
+- Annotated source (`pprof -list`) additionally needed the source tree the
+  binary was built from. The per-line sample counts come from the profile and
+  now always render; the source text is interleaved only where the file is
+  actually readable, and says so plainly where it is not
+- An empty profile rendered as an empty table, which reads as "this function
+  used no CPU". It now explains that the profiler samples at 100Hz and a call
+  shorter than that usually records nothing
+
+### Changed
+- `SetSamplingRate` and `WithSamplingRate` now document the cost of a sampled
+  call: `pprof.StopCPUProfile` blocks on the runtime's buffer flush for a
+  roughly constant ~200ms regardless of how long the function ran, measured at
+  201.8ms of overhead on a 1ms call. `ExecutionTime` is captured before the
+  stop, so the metric does not show it
+
 ### Changed
 - **13 compiled example binaries are no longer tracked** -- 502 MB, 95% of the
   repository. They were macOS arm64, so they could not run on Linux, Windows or

--- a/config_builder.go
+++ b/config_builder.go
@@ -93,7 +93,14 @@ func (b *MonigoBuilder) WithAuthFunction(authFunc func(*http.Request) bool) *Mon
 	return b
 }
 
-// WithSamplingRate sets the sampling rate for function tracing
+// WithSamplingRate sets the sampling rate for function tracing: one call in
+// every `rate` is profiled. The default is 100.
+//
+// The sampled call pays a roughly constant ~200ms, independent of how long the
+// function itself runs, because pprof.StopCPUProfile blocks on the runtime's
+// buffer flush -- and because the CPU profiler samples at 100Hz, a call
+// shorter than ~10ms usually captures nothing for that cost. See
+// core.SetSamplingRate for the measurements and what to do about it.
 func (b *MonigoBuilder) WithSamplingRate(rate int) *MonigoBuilder {
 	b.config.SamplingRate = rate
 	return b

--- a/core/function-metrics.go
+++ b/core/function-metrics.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -33,7 +32,36 @@ func init() {
 	samplingRate.Store(100)
 }
 
-// SetSamplingRate sets the sampling rate for function tracing
+// SetSamplingRate sets the sampling rate for function tracing: one call in
+// every `rate` is profiled. The default is 100.
+//
+// # The sampled call pays about 200ms
+//
+// Profiling a call is not cheap and the cost does not scale with the work.
+// pprof.StopCPUProfile blocks while the runtime flushes its profile buffer,
+// which takes a roughly constant ~200ms regardless of how long the function
+// ran. Measured here, a 1ms function:
+//
+//	sampled call:     202.9ms
+//	unsampled call:     1.1ms
+//	overhead:         201.8ms
+//
+// At the default rate a traced handler serving 100 rps stalls for ~200ms once
+// per second. ExecutionTime does not show this -- it is captured before the
+// stop -- so the recorded metric reads 1ms while the caller's goroutine was
+// blocked for 203ms. Anyone comparing MoniGo's numbers against their own
+// latency graphs will find them disagreeing on exactly one call in `rate`.
+//
+// # And the profile is usually empty
+//
+// Go's CPU profiler samples at 100Hz, so a call shorter than ~10ms typically
+// finishes between two samples and captures nothing. At the default settings
+// the common case is to pay the 200ms and get an empty profile.
+//
+// This closes off the obvious workaround: lowering `rate` to collect more
+// profiles makes the stall more frequent, and raising it makes profiles rarer
+// without making them any less empty. Trace functions that do enough work to
+// be worth sampling, and leave hot, short ones untraced.
 func SetSamplingRate(rate int) {
 	if rate < 1 {
 		rate = 1
@@ -314,61 +342,39 @@ func executeFunctionWithProfiling(name string, fn func()) {
 	}
 }
 
-// ViewFunctionMetrics generates the function metrics
+// ViewFunctionMetrics renders the stored profiles for one traced function.
+//
+// This used to shell out to `go tool pprof`, which meant the Go SDK had to be
+// installed on the machine running the service. In a distroless, scratch or
+// alpine image -- nearly every production deployment of a Go service -- it is
+// not, and this returned the string "Error: 'go' command not found" as the
+// report body. It also spawned a subprocess for every HTTP request.
+//
+// runtime/pprof writes fully symbolized profiles: the function names and file
+// paths are inside the file. Parsing needs no toolchain, no binary and no
+// source tree, so the reports are rendered in-process.
 func ViewFunctionMetrics(name, reportType string, metrics *models.FunctionMetrics) models.FunctionTraceDetails {
-	_, err := exec.LookPath("go")
-	if err != nil {
-		logger.Log.Warn("'go' command not found in PATH, pprof reports will be unavailable")
+	// A name arriving from a query string is no longer interpolated into a
+	// command line, so this is no longer a shell-injection guard. It stays
+	// because a name with control characters cannot match a real Go symbol and
+	// signals a malformed request.
+	if strings.HasPrefix(name, "-") || strings.ContainsAny(name, ";&|$` \t\n") {
 		return models.FunctionTraceDetails{
 			FunctionName: name,
 			CoreProfile: models.Profiles{
-				CPU: "Error: 'go' command not found. pprof reports require the Go SDK.",
-				Mem: "Error: 'go' command not found. pprof reports require the Go SDK.",
+				CPU: "Error: Invalid function name",
+				Mem: "Error: Invalid function name",
 			},
-			FunctionCodeTrace: "Error: 'go' command not found.",
-		}
-	}
-
-	// Validate function name to ensure it doesn't look like a flag or contain shell control characters
-	isNameInvalid := strings.HasPrefix(name, "-") || strings.ContainsAny(name, ";&|$` \t\n")
-
-	executePprof := func(profileFilePath, reportType string) string {
-		if isNameInvalid {
-			return "Error: Invalid function name"
-		}
-		if profileFilePath == "" {
-			return "Error: Profile file path is empty"
-		}
-		if reportType != "text" && reportType != "traces" && reportType != "tree" {
-			return "Error: Invalid report type"
-		}
-		cmd := exec.Command("go", "tool", "pprof", "-"+reportType, profileFilePath)
-		output, err := cmd.CombinedOutput()
-		if err != nil {
-			return fmt.Sprintf("Error executing pprof: %v\nOutput: %s", err, string(output))
-		}
-		return string(output)
-	}
-
-	var codeStack string
-	if isNameInvalid {
-		codeStack = "Error: Invalid function name"
-	} else if metrics.CPUProfileFilePath != "" {
-		codeStackView := exec.Command("go", "tool", "pprof", "-list", name, metrics.CPUProfileFilePath)
-		output, err := codeStackView.CombinedOutput()
-		if err != nil {
-			codeStack = fmt.Sprintf("Error generating code trace: %v\nOutput: %s", err, string(output))
-		} else {
-			codeStack = string(output)
+			FunctionCodeTrace: "Error: Invalid function name",
 		}
 	}
 
 	return models.FunctionTraceDetails{
 		FunctionName: name,
 		CoreProfile: models.Profiles{
-			CPU: executePprof(metrics.CPUProfileFilePath, reportType),
-			Mem: executePprof(metrics.MemProfileFilePath, reportType),
+			CPU: renderProfileReport(metrics.CPUProfileFilePath, reportType),
+			Mem: renderProfileReport(metrics.MemProfileFilePath, reportType),
 		},
-		FunctionCodeTrace: codeStack,
+		FunctionCodeTrace: renderAnnotatedSource(metrics.CPUProfileFilePath, name),
 	}
 }

--- a/core/profile_report.go
+++ b/core/profile_report.go
@@ -1,0 +1,538 @@
+package core
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/pprof/profile"
+)
+
+// In-process pprof rendering.
+//
+// This replaces `exec.Command("go", "tool", "pprof", ...)`. That required the
+// Go SDK on PATH at runtime, so on any distroless, scratch or alpine image --
+// which is to say nearly every production deployment of a Go service -- the
+// dashboard's profile view showed an error string instead of a profile. It
+// also spawned a subprocess per HTTP request.
+//
+// None of that was necessary. Profiles written by runtime/pprof are fully
+// symbolized: the function names and source paths are already inside the file.
+// Parsing one needs no binary, no source tree and no toolchain.
+
+// maxReportNodes caps how many rows a report renders. A deep profile can hold
+// thousands of functions, and the dashboard puts this in a <pre> block; the
+// tail of that list is noise nobody scrolls to.
+const maxReportNodes = 100
+
+// renderProfileReport reads a pprof profile and renders it as text.
+//
+// Errors are returned as the report body rather than as an error value,
+// because that is what the endpoint shows the operator: a profile that cannot
+// be read is a thing to display, not a request failure.
+func renderProfileReport(path, reportType string) string {
+	// Validate the report type before looking at the file, and reject an empty
+	// one. The API layer defaults "" to "text" before it reaches here, so an
+	// empty value arriving at this function means a caller bypassed that --
+	// which is worth rejecting rather than quietly guessing.
+	switch reportType {
+	case "text", "tree", "traces":
+	default:
+		return fmt.Sprintf("Error: Invalid report type %q. Supported: text, tree, traces.", reportType)
+	}
+
+	if path == "" {
+		return "No profile was captured for this function."
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "No profile on disk. Profiles are written only for sampled calls."
+		}
+		return fmt.Sprintf("Could not open the profile: %v", err)
+	}
+	defer f.Close()
+
+	p, err := profile.Parse(f)
+	if err != nil {
+		return fmt.Sprintf("Could not parse the profile: %v", err)
+	}
+
+	switch reportType {
+	case "tree":
+		return renderTree(p)
+	case "traces":
+		return renderTraces(p)
+	default: // "text", already validated above
+		return renderTop(p)
+	}
+}
+
+// valueIndex picks which of a sample's values to report on.
+//
+// A CPU profile carries [samples/count, cpu/nanoseconds]; a heap profile
+// carries four, of which inuse_space is the one people mean. pprof records its
+// own preference in DefaultSampleType, so honour that and fall back to the
+// last, which is the convention both profile kinds follow.
+func valueIndex(p *profile.Profile) int {
+	if p.DefaultSampleType != "" {
+		for i, st := range p.SampleType {
+			if st.Type == p.DefaultSampleType {
+				return i
+			}
+		}
+	}
+	if len(p.SampleType) == 0 {
+		return 0
+	}
+	return len(p.SampleType) - 1
+}
+
+// leafFunction returns the name of the frame a sample was actually executing.
+func leafFunction(s *profile.Sample) string {
+	for _, loc := range s.Location {
+		for _, ln := range loc.Line {
+			if ln.Function != nil {
+				return ln.Function.Name
+			}
+		}
+	}
+	return ""
+}
+
+type nodeStat struct {
+	name string
+	flat int64
+	cum  int64
+}
+
+// collect computes flat and cumulative totals per function.
+//
+// flat is what a function was executing itself; cum includes everything it
+// called. A function appearing twice in one stack -- recursion -- counts once
+// toward cum, otherwise a recursive call would multiply its own total.
+func collect(p *profile.Profile, idx int) (stats []nodeStat, total int64) {
+	flat := map[string]int64{}
+	cum := map[string]int64{}
+
+	for _, s := range p.Sample {
+		if idx >= len(s.Value) {
+			continue
+		}
+		v := s.Value[idx]
+		total += v
+
+		if leaf := leafFunction(s); leaf != "" {
+			flat[leaf] += v
+		}
+
+		seen := map[string]bool{}
+		for _, loc := range s.Location {
+			for _, ln := range loc.Line {
+				if ln.Function == nil || seen[ln.Function.Name] {
+					continue
+				}
+				seen[ln.Function.Name] = true
+				cum[ln.Function.Name] += v
+			}
+		}
+	}
+
+	for name, c := range cum {
+		stats = append(stats, nodeStat{name: name, flat: flat[name], cum: c})
+	}
+	// Functions that only ever appear as a leaf still need a row.
+	for name, fv := range flat {
+		if _, ok := cum[name]; !ok {
+			stats = append(stats, nodeStat{name: name, flat: fv, cum: fv})
+		}
+	}
+
+	sort.Slice(stats, func(i, j int) bool {
+		if stats[i].flat != stats[j].flat {
+			return stats[i].flat > stats[j].flat
+		}
+		if stats[i].cum != stats[j].cum {
+			return stats[i].cum > stats[j].cum
+		}
+		return stats[i].name < stats[j].name
+	})
+	return stats, total
+}
+
+// formatValue renders a sample value in the units the profile declares.
+func formatValue(v int64, unit string) string {
+	switch unit {
+	case "nanoseconds":
+		return time.Duration(v).String()
+	case "bytes":
+		return formatBytes(v)
+	default:
+		return fmt.Sprintf("%d", v)
+	}
+}
+
+func formatBytes(v int64) string {
+	const unit = 1024
+	if v < unit {
+		return fmt.Sprintf("%dB", v)
+	}
+	div, exp := int64(unit), 0
+	for n := v / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.2f%cB", float64(v)/float64(div), "KMGTPE"[exp])
+}
+
+func percent(part, whole int64) string {
+	if whole == 0 {
+		return "0%"
+	}
+	return fmt.Sprintf("%.2f%%", float64(part)/float64(whole)*100)
+}
+
+// header reproduces the preamble `go tool pprof` prints, which operators read
+// as much as the table: it says what was measured and for how long.
+func header(p *profile.Profile, idx int, total int64) string {
+	var b strings.Builder
+	st := "unknown"
+	unit := ""
+	if idx < len(p.SampleType) {
+		st = p.SampleType[idx].Type
+		unit = p.SampleType[idx].Unit
+	}
+	fmt.Fprintf(&b, "Type: %s\n", st)
+	if p.TimeNanos > 0 {
+		fmt.Fprintf(&b, "Time: %s\n", time.Unix(0, p.TimeNanos).UTC().Format(time.RFC3339))
+	}
+	if p.DurationNanos > 0 {
+		fmt.Fprintf(&b, "Duration: %s, Total samples = %s\n",
+			time.Duration(p.DurationNanos), formatValue(total, unit))
+	} else {
+		fmt.Fprintf(&b, "Total samples = %s\n", formatValue(total, unit))
+	}
+	return b.String()
+}
+
+// emptyNote explains a profile with nothing in it.
+//
+// This is the common case, not an edge case: Go's CPU profiler samples at
+// 100 Hz, so a call shorter than ~10ms usually captures nothing at all. A bare
+// empty table invites the reader to conclude the function is free.
+func emptyNote(p *profile.Profile) string {
+	if p.Period > 0 && p.PeriodType != nil && p.PeriodType.Unit == "nanoseconds" {
+		return fmt.Sprintf(
+			"\nNo samples. The CPU profiler samples every %s, so a call shorter "+
+				"than that usually finishes between two samples and records nothing. "+
+				"This does not mean the function used no CPU.\n",
+			time.Duration(p.Period))
+	}
+	return "\nNo samples were recorded in this profile.\n"
+}
+
+func renderTop(p *profile.Profile) string {
+	idx := valueIndex(p)
+	stats, total := collect(p, idx)
+
+	var b strings.Builder
+	b.WriteString(header(p, idx, total))
+	if len(stats) == 0 || total == 0 {
+		b.WriteString(emptyNote(p))
+		return b.String()
+	}
+
+	unit := ""
+	if idx < len(p.SampleType) {
+		unit = p.SampleType[idx].Unit
+	}
+
+	shown := stats
+	if len(shown) > maxReportNodes {
+		shown = shown[:maxReportNodes]
+	}
+	var accounted int64
+	for _, s := range shown {
+		accounted += s.flat
+	}
+	fmt.Fprintf(&b, "Showing nodes accounting for %s, %s of %s total\n\n",
+		formatValue(accounted, unit), percent(accounted, total), formatValue(total, unit))
+
+	fmt.Fprintf(&b, "%10s %7s %7s %10s %7s  %s\n", "flat", "flat%", "sum%", "cum", "cum%", "function")
+	var running int64
+	for _, s := range shown {
+		running += s.flat
+		fmt.Fprintf(&b, "%10s %7s %7s %10s %7s  %s\n",
+			formatValue(s.flat, unit), percent(s.flat, total), percent(running, total),
+			formatValue(s.cum, unit), percent(s.cum, total), s.name)
+	}
+	if len(stats) > len(shown) {
+		fmt.Fprintf(&b, "\n(%d more functions not shown)\n", len(stats)-len(shown))
+	}
+	return b.String()
+}
+
+// renderTree shows each function with the callers that reached it and the
+// callees it reached, which is what `pprof -tree` is for.
+func renderTree(p *profile.Profile) string {
+	idx := valueIndex(p)
+	stats, total := collect(p, idx)
+
+	var b strings.Builder
+	b.WriteString(header(p, idx, total))
+	if len(stats) == 0 || total == 0 {
+		b.WriteString(emptyNote(p))
+		return b.String()
+	}
+
+	unit := ""
+	if idx < len(p.SampleType) {
+		unit = p.SampleType[idx].Unit
+	}
+
+	// Edge weights, keyed caller -> callee. Location order within a sample is
+	// leaf-first, so the caller of frame i is frame i+1.
+	callers := map[string]map[string]int64{}
+	callees := map[string]map[string]int64{}
+	for _, s := range p.Sample {
+		if idx >= len(s.Value) {
+			continue
+		}
+		v := s.Value[idx]
+		frames := sampleFunctions(s)
+		for i := 0; i+1 < len(frames); i++ {
+			callee, caller := frames[i], frames[i+1]
+			if callers[callee] == nil {
+				callers[callee] = map[string]int64{}
+			}
+			if callees[caller] == nil {
+				callees[caller] = map[string]int64{}
+			}
+			callers[callee][caller] += v
+			callees[caller][callee] += v
+		}
+	}
+
+	shown := stats
+	if len(shown) > maxReportNodes {
+		shown = shown[:maxReportNodes]
+	}
+	fmt.Fprintf(&b, "Showing top %d nodes out of %d\n", len(shown), len(stats))
+
+	for _, s := range shown {
+		b.WriteString("\n----------------------------------------------------------\n")
+		for _, e := range sortedEdges(callers[s.name]) {
+			fmt.Fprintf(&b, "%12s %7s |   %s\n", formatValue(e.weight, unit), percent(e.weight, total), e.name)
+		}
+		fmt.Fprintf(&b, "%12s %7s %10s %7s  %s\n",
+			formatValue(s.flat, unit), percent(s.flat, total),
+			formatValue(s.cum, unit), percent(s.cum, total), s.name)
+		for _, e := range sortedEdges(callees[s.name]) {
+			fmt.Fprintf(&b, "%12s %7s |     %s\n", formatValue(e.weight, unit), percent(e.weight, total), e.name)
+		}
+	}
+	return b.String()
+}
+
+// renderTraces lists every distinct stack with its value.
+func renderTraces(p *profile.Profile) string {
+	idx := valueIndex(p)
+	_, total := collect(p, idx)
+
+	var b strings.Builder
+	b.WriteString(header(p, idx, total))
+	if len(p.Sample) == 0 {
+		b.WriteString(emptyNote(p))
+		return b.String()
+	}
+
+	unit := ""
+	if idx < len(p.SampleType) {
+		unit = p.SampleType[idx].Unit
+	}
+
+	for i, s := range p.Sample {
+		if i >= maxReportNodes {
+			fmt.Fprintf(&b, "\n(%d more samples not shown)\n", len(p.Sample)-maxReportNodes)
+			break
+		}
+		if idx >= len(s.Value) {
+			continue
+		}
+		b.WriteString("-----------+-------------------------------------------------------\n")
+		frames := sampleFunctions(s)
+		for j, fn := range frames {
+			if j == 0 {
+				fmt.Fprintf(&b, "%10s   %s\n", formatValue(s.Value[idx], unit), fn)
+				continue
+			}
+			fmt.Fprintf(&b, "%10s   %s\n", "", fn)
+		}
+	}
+	return b.String()
+}
+
+// sampleFunctions returns a sample's frames, leaf first.
+func sampleFunctions(s *profile.Sample) []string {
+	var out []string
+	for _, loc := range s.Location {
+		for _, ln := range loc.Line {
+			if ln.Function != nil {
+				out = append(out, ln.Function.Name)
+			}
+		}
+	}
+	return out
+}
+
+type edge struct {
+	name   string
+	weight int64
+}
+
+func sortedEdges(m map[string]int64) []edge {
+	out := make([]edge, 0, len(m))
+	for n, w := range m {
+		out = append(out, edge{name: n, weight: w})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].weight != out[j].weight {
+			return out[i].weight > out[j].weight
+		}
+		return out[i].name < out[j].name
+	})
+	return out
+}
+
+// renderAnnotatedSource replaces `go tool pprof -list`.
+//
+// -list needed two things production does not have: the Go toolchain, and the
+// source tree the binary was built from. This splits those apart. The
+// per-line sample counts come from the profile itself, which always carries
+// them, so the useful half works in a scratch container. The source text is
+// read from the path the profile recorded and interleaved only when that file
+// is actually readable -- on a developer machine it usually is, in a container
+// it usually is not, and saying so is better than an error that reads like a
+// malfunction.
+func renderAnnotatedSource(path, funcName string) string {
+	if path == "" {
+		return "No CPU profile was captured for this function."
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "No profile on disk. Profiles are written only for sampled calls."
+		}
+		return fmt.Sprintf("Could not open the profile: %v", err)
+	}
+	defer f.Close()
+
+	p, err := profile.Parse(f)
+	if err != nil {
+		return fmt.Sprintf("Could not parse the profile: %v", err)
+	}
+
+	idx := valueIndex(p)
+	unit := ""
+	if idx < len(p.SampleType) {
+		unit = p.SampleType[idx].Unit
+	}
+
+	// line number -> flat value, for the requested function only.
+	perLine := map[int64]int64{}
+	var sourceFile string
+	var total int64
+
+	for _, s := range p.Sample {
+		if idx >= len(s.Value) {
+			continue
+		}
+		v := s.Value[idx]
+		// Only the leaf frame attributes flat cost to a line.
+		for _, loc := range s.Location {
+			hit := false
+			for _, ln := range loc.Line {
+				if ln.Function == nil || ln.Function.Name != funcName {
+					continue
+				}
+				perLine[ln.Line] += v
+				total += v
+				if sourceFile == "" {
+					sourceFile = ln.Function.Filename
+				}
+				hit = true
+			}
+			if hit {
+				break
+			}
+		}
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Function: %s\n", funcName)
+	if sourceFile != "" {
+		fmt.Fprintf(&b, "File: %s\n", sourceFile)
+	}
+	fmt.Fprintf(&b, "Type: %s\n\n", sampleTypeName(p, idx))
+
+	if len(perLine) == 0 {
+		b.WriteString("No samples fell inside this function.\n")
+		b.WriteString(strings.TrimPrefix(emptyNote(p), "\n"))
+		return b.String()
+	}
+
+	src, srcErr := os.ReadFile(sourceFile)
+	if srcErr != nil {
+		fmt.Fprintf(&b, "Source is not available on this host, so only the line "+
+			"numbers the profiler recorded are shown.\n\n")
+		for _, ln := range sortedLines(perLine) {
+			fmt.Fprintf(&b, "%12s  %s:%d\n", formatValue(perLine[ln], unit), sourceFile, ln)
+		}
+		return b.String()
+	}
+
+	lines := strings.Split(string(src), "\n")
+	shown := sortedLines(perLine)
+	first, last := shown[0], shown[len(shown)-1]
+	// A little context either side, clamped to the file.
+	const pad = 3
+	from, to := int(first)-pad, int(last)+pad
+	if from < 1 {
+		from = 1
+	}
+	if to > len(lines) {
+		to = len(lines)
+	}
+
+	for i := from; i <= to; i++ {
+		v, ok := perLine[int64(i)]
+		marker := "     "
+		amount := ""
+		if ok && v > 0 {
+			marker = "  .  "
+			amount = formatValue(v, unit)
+		}
+		fmt.Fprintf(&b, "%12s %s %5d:  %s\n", amount, marker, i, lines[i-1])
+	}
+	return b.String()
+}
+
+func sampleTypeName(p *profile.Profile, idx int) string {
+	if idx < len(p.SampleType) {
+		return p.SampleType[idx].Type
+	}
+	return "unknown"
+}
+
+func sortedLines(m map[int64]int64) []int64 {
+	out := make([]int64, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}

--- a/core/profile_report_test.go
+++ b/core/profile_report_test.go
@@ -1,0 +1,201 @@
+package core
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime/pprof"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writeCPUProfile captures a real profile of some busy work and returns its
+// path. Real profiles rather than fixtures: the whole claim under test is that
+// what runtime/pprof writes is self-describing.
+func writeCPUProfile(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "cpu.prof")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	if err := pprof.StartCPUProfile(f); err != nil {
+		t.Skipf("CPU profiling unavailable: %v", err)
+	}
+	// Long enough to catch samples at the profiler's 100 Hz.
+	deadline := time.Now().Add(300 * time.Millisecond)
+	x := 0.0
+	for time.Now().Before(deadline) {
+		for i := 0; i < 200000; i++ {
+			x += float64(i % 7)
+		}
+	}
+	pprof.StopCPUProfile()
+	_ = x
+	return path
+}
+
+// TestReportsRenderWithoutTheGoToolchain is the point of the change.
+//
+// The previous implementation ran `go tool pprof`, so on any image without the
+// Go SDK -- distroless, scratch, alpine -- the dashboard showed
+// "Error: 'go' command not found" where the profile should be. Emptying PATH
+// reproduces that environment: if anything still shells out, this fails.
+func TestReportsRenderWithoutTheGoToolchain(t *testing.T) {
+	path := writeCPUProfile(t)
+
+	t.Setenv("PATH", "")
+	if _, err := exec.LookPath("go"); err == nil {
+		t.Skip("go is still resolvable with an empty PATH on this system")
+	}
+
+	report := renderProfileReport(path, "text")
+	if strings.Contains(report, "command not found") || strings.Contains(report, "Error") {
+		t.Fatalf("report reads as an error with no toolchain:\n%s", report)
+	}
+	if !strings.Contains(report, "Type: cpu") {
+		t.Errorf("no profile type header:\n%s", report)
+	}
+	// The function under test must appear by name, from the profile alone --
+	// no binary and no source tree were consulted.
+	if !strings.Contains(report, "monigo/core.writeCPUProfile") {
+		t.Errorf("the profiled function is not named in the report:\n%s", report)
+	}
+}
+
+func TestEveryReportTypeRenders(t *testing.T) {
+	path := writeCPUProfile(t)
+	for _, rt := range []string{"text", "tree", "traces"} {
+		t.Run(rt, func(t *testing.T) {
+			got := renderProfileReport(path, rt)
+			if got == "" {
+				t.Fatal("empty report")
+			}
+			if strings.Contains(got, "Invalid report type") {
+				t.Fatalf("%q was rejected: %s", rt, got)
+			}
+			if !strings.Contains(got, "Type: cpu") {
+				t.Errorf("missing header:\n%s", got)
+			}
+		})
+	}
+}
+
+func TestUnknownReportTypeIsNamed(t *testing.T) {
+	path := writeCPUProfile(t)
+	got := renderProfileReport(path, "flamegraph")
+	if !strings.Contains(got, "Invalid report type") || !strings.Contains(got, "flamegraph") ||
+		!strings.Contains(got, "Supported") {
+		t.Errorf("an unknown type should say so and list the alternatives, got:\n%s", got)
+	}
+}
+
+// An empty profile is the common case, not an edge case: the CPU profiler
+// samples at 100 Hz, so a sub-10ms call usually records nothing. A bare empty
+// table would invite the reader to conclude the function is free.
+func TestAnEmptyProfileExplainsItself(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "empty.prof")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := pprof.StartCPUProfile(f); err != nil {
+		t.Skipf("CPU profiling unavailable: %v", err)
+	}
+	pprof.StopCPUProfile()
+	f.Close()
+
+	got := renderProfileReport(path, "text")
+	if !strings.Contains(got, "No samples") {
+		t.Errorf("an empty profile should say so:\n%s", got)
+	}
+	if !strings.Contains(got, "does not mean the function used no CPU") {
+		t.Errorf("an empty profile should explain why it is empty:\n%s", got)
+	}
+}
+
+func TestMissingProfileIsNotAnError(t *testing.T) {
+	got := renderProfileReport(filepath.Join(t.TempDir(), "nope.prof"), "text")
+	if !strings.Contains(got, "Profiles are written only for sampled calls") {
+		t.Errorf("an absent profile should explain sampling, got: %s", got)
+	}
+	if got := renderProfileReport("", "text"); !strings.Contains(got, "No profile") {
+		t.Errorf("an empty path should say no profile was captured, got: %s", got)
+	}
+}
+
+func TestCorruptProfileReportsTheParseFailure(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "junk.prof")
+	if err := os.WriteFile(path, []byte("this is not a pprof profile"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := renderProfileReport(path, "text"); !strings.Contains(got, "Could not parse") {
+		t.Errorf("expected a parse failure, got: %s", got)
+	}
+}
+
+// Annotated source must degrade to line numbers rather than failing outright:
+// the per-line counts come from the profile and are always available, while
+// the source text is only present on a machine that has the tree.
+func TestAnnotatedSourceWorksWithoutTheSourceTree(t *testing.T) {
+	path := writeCPUProfile(t)
+	got := renderAnnotatedSource(path, "github.com/iyashjayesh/monigo/core.writeCPUProfile")
+	if !strings.Contains(got, "Function:") {
+		t.Fatalf("no function header:\n%s", got)
+	}
+	// This machine has the source, so the real lines should appear.
+	if !strings.Contains(got, "deadline") && !strings.Contains(got, "Source is not available") {
+		t.Errorf("neither annotated source nor the fallback appeared:\n%s", got)
+	}
+}
+
+func TestRecursionCountsOnceTowardCumulative(t *testing.T) {
+	// A function appearing twice in one stack must not have its own cumulative
+	// total doubled by its own recursive frame.
+	path := writeCPUProfile(t)
+	report := renderProfileReport(path, "text")
+	for _, line := range strings.Split(report, "\n") {
+		if !strings.Contains(line, "monigo/core.") {
+			continue
+		}
+		// cum% is the fifth column; nothing may exceed 100%.
+		fields := strings.Fields(line)
+		if len(fields) < 5 {
+			continue
+		}
+		cumPct := strings.TrimSuffix(fields[4], "%")
+		if cumPct != "" && len(cumPct) > 0 {
+			if v := parseFloat(cumPct); v > 100.01 {
+				t.Errorf("cumulative %.2f%% exceeds the total in: %s", v, line)
+			}
+		}
+	}
+}
+
+func parseFloat(s string) float64 {
+	var f float64
+	var neg bool
+	i := 0
+	if i < len(s) && (s[i] == '-' || s[i] == '+') {
+		neg = s[i] == '-'
+		i++
+	}
+	for ; i < len(s) && s[i] >= '0' && s[i] <= '9'; i++ {
+		f = f*10 + float64(s[i]-'0')
+	}
+	if i < len(s) && s[i] == '.' {
+		i++
+		scale := 0.1
+		for ; i < len(s) && s[i] >= '0' && s[i] <= '9'; i++ {
+			f += float64(s[i]-'0') * scale
+			scale /= 10
+		}
+	}
+	if neg {
+		return -f
+	}
+	return f
+}

--- a/example/function-trace-example/go.mod
+++ b/example/function-trace-example/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/gofiber/fiber/v2 v2.52.10 // indirect
+	github.com/google/pprof v0.0.0-20250607225305-033d6d78b36a // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7 // indirect
 	github.com/klauspost/compress v1.18.2 // indirect

--- a/example/function-trace-example/go.sum
+++ b/example/function-trace-example/go.sum
@@ -26,6 +26,8 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/pprof v0.0.0-20250607225305-033d6d78b36a h1://KbezygeMJZCSHH+HgUZiTeSoiuFspbMg1ge+eFj18=
+github.com/google/pprof v0.0.0-20250607225305-033d6d78b36a/go.mod h1:5hDyRhoBCxViHszMt12TnOpEI4VVi+U8Gm9iphldiMA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7 h1:X+2YciYSxvMQK0UZ7sg45ZVabVZBeBuvMkmuI2V3Fak=

--- a/example/go.mod
+++ b/example/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/gofiber/fiber/v2 v2.52.10 // indirect
+	github.com/google/pprof v0.0.0-20250607225305-033d6d78b36a // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7 // indirect
 	github.com/klauspost/compress v1.18.2 // indirect

--- a/example/go.sum
+++ b/example/go.sum
@@ -26,6 +26,8 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/pprof v0.0.0-20250607225305-033d6d78b36a h1://KbezygeMJZCSHH+HgUZiTeSoiuFspbMg1ge+eFj18=
+github.com/google/pprof v0.0.0-20250607225305-033d6d78b36a/go.mod h1:5hDyRhoBCxViHszMt12TnOpEI4VVi+U8Gm9iphldiMA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7 h1:X+2YciYSxvMQK0UZ7sg45ZVabVZBeBuvMkmuI2V3Fak=

--- a/example/router-integration/echo-integration/go.mod
+++ b/example/router-integration/echo-integration/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/gofiber/fiber/v2 v2.52.10 // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
+	github.com/google/pprof v0.0.0-20250607225305-033d6d78b36a // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7 // indirect
 	github.com/klauspost/compress v1.18.2 // indirect

--- a/example/router-integration/echo-integration/go.sum
+++ b/example/router-integration/echo-integration/go.sum
@@ -29,6 +29,8 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/pprof v0.0.0-20250607225305-033d6d78b36a h1://KbezygeMJZCSHH+HgUZiTeSoiuFspbMg1ge+eFj18=
+github.com/google/pprof v0.0.0-20250607225305-033d6d78b36a/go.mod h1:5hDyRhoBCxViHszMt12TnOpEI4VVi+U8Gm9iphldiMA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7 h1:X+2YciYSxvMQK0UZ7sg45ZVabVZBeBuvMkmuI2V3Fak=

--- a/example/router-integration/fiber-integration/go.mod
+++ b/example/router-integration/fiber-integration/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
+	github.com/google/pprof v0.0.0-20250607225305-033d6d78b36a // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7 // indirect
 	github.com/klauspost/compress v1.18.2 // indirect

--- a/example/router-integration/fiber-integration/go.sum
+++ b/example/router-integration/fiber-integration/go.sum
@@ -26,6 +26,8 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/pprof v0.0.0-20250607225305-033d6d78b36a h1://KbezygeMJZCSHH+HgUZiTeSoiuFspbMg1ge+eFj18=
+github.com/google/pprof v0.0.0-20250607225305-033d6d78b36a/go.mod h1:5hDyRhoBCxViHszMt12TnOpEI4VVi+U8Gm9iphldiMA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7 h1:X+2YciYSxvMQK0UZ7sg45ZVabVZBeBuvMkmuI2V3Fak=

--- a/example/router-integration/gin-integration/go.mod
+++ b/example/router-integration/gin-integration/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/go-playground/validator/v10 v10.14.0 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/gofiber/fiber/v2 v2.52.10 // indirect
+	github.com/google/pprof v0.0.0-20250607225305-033d6d78b36a // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/example/router-integration/gin-integration/go.sum
+++ b/example/router-integration/gin-integration/go.sum
@@ -50,6 +50,8 @@ github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/pprof v0.0.0-20250607225305-033d6d78b36a h1://KbezygeMJZCSHH+HgUZiTeSoiuFspbMg1ge+eFj18=
+github.com/google/pprof v0.0.0-20250607225305-033d6d78b36a/go.mod h1:5hDyRhoBCxViHszMt12TnOpEI4VVi+U8Gm9iphldiMA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7 h1:X+2YciYSxvMQK0UZ7sg45ZVabVZBeBuvMkmuI2V3Fak=

--- a/example/router-integration/gorilla-mux-integration/go.mod
+++ b/example/router-integration/gorilla-mux-integration/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/gofiber/fiber/v2 v2.52.10 // indirect
+	github.com/google/pprof v0.0.0-20250607225305-033d6d78b36a // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7 // indirect
 	github.com/klauspost/compress v1.18.2 // indirect

--- a/example/router-integration/gorilla-mux-integration/go.sum
+++ b/example/router-integration/gorilla-mux-integration/go.sum
@@ -26,6 +26,8 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/pprof v0.0.0-20250607225305-033d6d78b36a h1://KbezygeMJZCSHH+HgUZiTeSoiuFspbMg1ge+eFj18=
+github.com/google/pprof v0.0.0-20250607225305-033d6d78b36a/go.mod h1:5hDyRhoBCxViHszMt12TnOpEI4VVi+U8Gm9iphldiMA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=

--- a/example/router-integration/standard-mux-integration/go.mod
+++ b/example/router-integration/standard-mux-integration/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/gofiber/fiber/v2 v2.52.10 // indirect
+	github.com/google/pprof v0.0.0-20250607225305-033d6d78b36a // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7 // indirect
 	github.com/klauspost/compress v1.18.2 // indirect

--- a/example/router-integration/standard-mux-integration/go.sum
+++ b/example/router-integration/standard-mux-integration/go.sum
@@ -26,6 +26,8 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/pprof v0.0.0-20250607225305-033d6d78b36a h1://KbezygeMJZCSHH+HgUZiTeSoiuFspbMg1ge+eFj18=
+github.com/google/pprof v0.0.0-20250607225305-033d6d78b36a/go.mod h1:5hDyRhoBCxViHszMt12TnOpEI4VVi+U8Gm9iphldiMA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7 h1:X+2YciYSxvMQK0UZ7sg45ZVabVZBeBuvMkmuI2V3Fak=

--- a/example/security-examples/api-key/go.mod
+++ b/example/security-examples/api-key/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/gofiber/fiber/v2 v2.52.10 // indirect
+	github.com/google/pprof v0.0.0-20250607225305-033d6d78b36a // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7 // indirect
 	github.com/klauspost/compress v1.18.2 // indirect

--- a/example/security-examples/api-key/go.sum
+++ b/example/security-examples/api-key/go.sum
@@ -26,6 +26,8 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/pprof v0.0.0-20250607225305-033d6d78b36a h1://KbezygeMJZCSHH+HgUZiTeSoiuFspbMg1ge+eFj18=
+github.com/google/pprof v0.0.0-20250607225305-033d6d78b36a/go.mod h1:5hDyRhoBCxViHszMt12TnOpEI4VVi+U8Gm9iphldiMA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7 h1:X+2YciYSxvMQK0UZ7sg45ZVabVZBeBuvMkmuI2V3Fak=

--- a/example/security-examples/basic-auth/go.mod
+++ b/example/security-examples/basic-auth/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/gofiber/fiber/v2 v2.52.10 // indirect
+	github.com/google/pprof v0.0.0-20250607225305-033d6d78b36a // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7 // indirect
 	github.com/klauspost/compress v1.18.2 // indirect

--- a/example/security-examples/basic-auth/go.sum
+++ b/example/security-examples/basic-auth/go.sum
@@ -26,6 +26,8 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/pprof v0.0.0-20250607225305-033d6d78b36a h1://KbezygeMJZCSHH+HgUZiTeSoiuFspbMg1ge+eFj18=
+github.com/google/pprof v0.0.0-20250607225305-033d6d78b36a/go.mod h1:5hDyRhoBCxViHszMt12TnOpEI4VVi+U8Gm9iphldiMA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7 h1:X+2YciYSxvMQK0UZ7sg45ZVabVZBeBuvMkmuI2V3Fak=

--- a/example/security-examples/chi/go.mod
+++ b/example/security-examples/chi/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/gofiber/fiber/v2 v2.52.10 // indirect
+	github.com/google/pprof v0.0.0-20250607225305-033d6d78b36a // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7 // indirect
 	github.com/klauspost/compress v1.18.2 // indirect

--- a/example/security-examples/chi/go.sum
+++ b/example/security-examples/chi/go.sum
@@ -12,8 +12,6 @@ github.com/clipperhouse/uax29/v2 v2.3.0 h1:SNdx9DVUqMoBuBoW3iLOj4FQv3dN5mDtuqwuh
 github.com/clipperhouse/uax29/v2 v2.3.0/go.mod h1:Wn1g7MK6OoeDT0vL+Q0SQLDz/KpfsVRgg6W7ihQeh4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/go-chi/chi/v5 v5.0.10 h1:rLz5avzKpjqxrYwXNfmjkrYYXOyLJd37pz53UFHC6vk=
-github.com/go-chi/chi/v5 v5.0.10/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
 github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -30,6 +28,8 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/pprof v0.0.0-20250607225305-033d6d78b36a h1://KbezygeMJZCSHH+HgUZiTeSoiuFspbMg1ge+eFj18=
+github.com/google/pprof v0.0.0-20250607225305-033d6d78b36a/go.mod h1:5hDyRhoBCxViHszMt12TnOpEI4VVi+U8Gm9iphldiMA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7 h1:X+2YciYSxvMQK0UZ7sg45ZVabVZBeBuvMkmuI2V3Fak=

--- a/example/security-examples/custom-auth/go.mod
+++ b/example/security-examples/custom-auth/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/gofiber/fiber/v2 v2.52.10 // indirect
+	github.com/google/pprof v0.0.0-20250607225305-033d6d78b36a // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7 // indirect
 	github.com/klauspost/compress v1.18.2 // indirect

--- a/example/security-examples/custom-auth/go.sum
+++ b/example/security-examples/custom-auth/go.sum
@@ -26,6 +26,8 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/pprof v0.0.0-20250607225305-033d6d78b36a h1://KbezygeMJZCSHH+HgUZiTeSoiuFspbMg1ge+eFj18=
+github.com/google/pprof v0.0.0-20250607225305-033d6d78b36a/go.mod h1:5hDyRhoBCxViHszMt12TnOpEI4VVi+U8Gm9iphldiMA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7 h1:X+2YciYSxvMQK0UZ7sg45ZVabVZBeBuvMkmuI2V3Fak=

--- a/example/security-examples/echo/go.mod
+++ b/example/security-examples/echo/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/gofiber/fiber/v2 v2.52.10 // indirect
+	github.com/google/pprof v0.0.0-20250607225305-033d6d78b36a // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7 // indirect
 	github.com/klauspost/compress v1.18.2 // indirect

--- a/example/security-examples/echo/go.sum
+++ b/example/security-examples/echo/go.sum
@@ -27,6 +27,8 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/pprof v0.0.0-20250607225305-033d6d78b36a h1://KbezygeMJZCSHH+HgUZiTeSoiuFspbMg1ge+eFj18=
+github.com/google/pprof v0.0.0-20250607225305-033d6d78b36a/go.mod h1:5hDyRhoBCxViHszMt12TnOpEI4VVi+U8Gm9iphldiMA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7 h1:X+2YciYSxvMQK0UZ7sg45ZVabVZBeBuvMkmuI2V3Fak=

--- a/example/security-examples/ip-whitelist-example/go.mod
+++ b/example/security-examples/ip-whitelist-example/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/gofiber/fiber/v2 v2.52.10 // indirect
+	github.com/google/pprof v0.0.0-20250607225305-033d6d78b36a // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7 // indirect
 	github.com/klauspost/compress v1.18.2 // indirect

--- a/example/security-examples/ip-whitelist-example/go.sum
+++ b/example/security-examples/ip-whitelist-example/go.sum
@@ -26,6 +26,8 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/pprof v0.0.0-20250607225305-033d6d78b36a h1://KbezygeMJZCSHH+HgUZiTeSoiuFspbMg1ge+eFj18=
+github.com/google/pprof v0.0.0-20250607225305-033d6d78b36a/go.mod h1:5hDyRhoBCxViHszMt12TnOpEI4VVi+U8Gm9iphldiMA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7 h1:X+2YciYSxvMQK0UZ7sg45ZVabVZBeBuvMkmuI2V3Fak=

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24.0
 
 require (
 	github.com/gofiber/fiber/v2 v2.52.10
+	github.com/google/pprof v0.0.0-20250607225305-033d6d78b36a
 	github.com/nakabonne/tstorage v0.3.6
 	github.com/prometheus/client_golang v1.23.2
 	github.com/shirou/gopsutil v3.21.11+incompatible

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/pprof v0.0.0-20250607225305-033d6d78b36a h1://KbezygeMJZCSHH+HgUZiTeSoiuFspbMg1ge+eFj18=
+github.com/google/pprof v0.0.0-20250607225305-033d6d78b36a/go.mod h1:5hDyRhoBCxViHszMt12TnOpEI4VVi+U8Gm9iphldiMA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7 h1:X+2YciYSxvMQK0UZ7sg45ZVabVZBeBuvMkmuI2V3Fak=


### PR DESCRIPTION
Closes #73. Unblocks #43.

## The feature only worked on a developer machine

`ViewFunctionMetrics` shelled out to `go tool pprof`. On any distroless, scratch or alpine image — **nearly every production deployment of a Go service** — `go` is not on `PATH`, so the dashboard returned this as the report body:

```
Error: 'go' command not found. pprof reports require the Go SDK.
```

None of it was necessary. Profiles written by `runtime/pprof` are **fully symbolized**. Parsing one straight out of this repo:

```
main.highCPUUsage  (/Users/.../example/main.go:49)
github.com/iyashjayesh/monigo/core.executeFunctionWithProfiling  (/Users/.../core/function-metrics.go:185)
```

Names and source paths are already inside the file. No binary, no source tree, no toolchain.

## The test is the proof

`TestReportsRenderWithoutTheGoToolchain` empties `PATH`, confirms `go` is unresolvable, and asserts a real report still comes back naming the profiled function. That is what makes the dependency *gone* rather than merely unused. `os/exec` is no longer imported by `core/function-metrics.go`, which also closes the subprocess-per-GET surface.

## The pin is deliberate

`github.com/google/pprof` at **`v0.0.0-20250607225305-033d6d78b36a`**, not latest.

Current pprof declares `go 1.25.0`. Taking it would raise this module's directive from `1.24.0` and **force every consumer onto Go 1.25**. This pin declares `go 1.23.0`, so the directive is unchanged and CI stays on 1.24. The `profile` package imports **stdlib only** — verified with `go list -deps` — so nothing else reaches consumers' builds.

## Two honesty fixes that came with it

**`-list` needed the source tree**, not just the toolchain. Those are now separate concerns: per-line sample counts come from the profile and always render; source text is interleaved only where the file is readable, and says so plainly where it is not.

**An empty profile rendered as an empty table**, which reads as "this function used no CPU". It now explains the 100Hz sampling. That is the common case, not an edge case — all 14 CPU profiles on disk here are 211–212 bytes, the size of a profile with zero samples.

## The ~200ms stall: documented, not moved

Moving the stop-and-write off the caller's goroutine is possible but delicate — CPU profiling is a process-wide singleton and #69 already fixed one corruption in this path. So `SetSamplingRate` and `WithSamplingRate` now carry the measurement:

```
sampled call:     202.9ms
unsampled call:     1.1ms
overhead:         201.8ms
```

...plus the fact that `ExecutionTime` is captured *before* the stop and so hides it, and why lowering the rate is not a workaround (more profiles means more stalls; fewer stalls means profiles that are just as empty).

## Verified against the real thing

Output was checked against `go tool pprof -top`, not only against the tests — same columns, same header, correct flat/cum/sum, and the annotated source attributes 250ms to the correct hot line:

```
      flat   flat%    sum%        cum    cum%  function
     210ms  84.00%  84.00%      250ms 100.00%  ...core.writeCPUProfile
      40ms  16.00% 100.00%       40ms  16.00%  runtime.asyncPreempt
```

`go test -race ./...` green across all 12 packages, `go vet` clean.