### PR TITLE
docs: show the current dashboard in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 **MoniGo** is a lightweight, embeddable observability library for Go services. It collects runtime metrics (CPU, memory, goroutines, disk/network I/O), traces function execution with pprof profiling, stores time-series data, and serves a real-time dashboard - all from a single `go get`.
 
 <div align="center">
-  <img src="https://raw.githubusercontent.com/iyashjayesh/monigo/assets/monigo.gif" width="100%" alt="MoniGo dashboard">
+  <img src="https://raw.githubusercontent.com/iyashjayesh/monigo/assets/hero.webp" width="100%" alt="MoniGo dashboard - overview">
 </div>
 
 ## Features
@@ -27,6 +27,32 @@
 - **Dashboard Security** - Basic Auth, API Key, IP Whitelist, Rate Limiting middleware
 - **Headless Mode** - Run as a background telemetry agent without the dashboard
 - **Builder API** - Type-safe, chainable configuration with validation
+
+### Per-function metrics
+
+Call counts and approximate latency percentiles for every traced function, with
+memory and goroutine deltas. Percentiles are bucket upper bounds, shown as `~4ms`
+meaning "at most 4ms", and read `-` below 20 calls rather than pretending three
+samples make a p95.
+
+<img src="https://raw.githubusercontent.com/iyashjayesh/monigo/assets/page-functions.webp" width="100%" alt="Per-function metrics with call counts and latency percentiles">
+
+### Goroutine inspection
+
+Live goroutines grouped by stack signature, with state, how long each group has
+been blocked, and growth across snapshots -- so a leak shows up as a group that
+keeps growing rather than a number that keeps rising.
+
+<img src="https://raw.githubusercontent.com/iyashjayesh/monigo/assets/page-goroutines.webp" width="100%" alt="Goroutines grouped by stack signature with leak detection">
+
+### Exporter status
+
+Prometheus and OpenTelemetry reported in their own terms. MoniGo is scraped by
+Prometheus and pushes to OTel, so the pull exporter shows when it was last
+scraped and carries no failure count -- a failed scrape fails at the collector,
+and the server never hears about it.
+
+<img src="https://raw.githubusercontent.com/iyashjayesh/monigo/assets/page-exporters.webp" width="100%" alt="Prometheus and OpenTelemetry exporter status">
 
 ## Installation
 


### PR DESCRIPTION
The README hero was still `monigo.gif` — the **pre-rebuild** dashboard, with a nav reading "Dashboards / Function Metrics / Go Routines Stats" against the current "Overview / Functions / Goroutines / Reports / Exporters". It had been advertising a UI the project no longer ships.

## What changes

**Hero** replaced with `hero.webp`, and three page images added under Features — per-function metrics, goroutine inspection, exporter status — each with a caption saying what the screenshot shows rather than restating the page title already visible in it.

| | |
| --- | --- |
| `hero.webp` | 67 KB |
| `page-functions.webp` | 36 KB |
| `page-goroutines.webp` | 73 KB |
| `page-exporters.webp` | 28 KB |
| **Total** | **234 KB** |
| `monigo.gif`, for comparison | **24,690 KB** |

All four live on the `assets` branch, which is never tagged, so **none of it enters the module zip.** `go get` pays nothing for any of it, however much imagery gets added later.

## The dashboard is photographed, not drawn

Each image is a real capture of a running service: `orders-api`, four traced functions under continuous load, 8,900+ recorded calls, 42 live goroutines, both exporters healthy with real scrape and push counts.

Only the **backdrop** is generated, and its palette is read from the product's own tokens — `--bg #080B10`, `--line #1D2531`, `--acc #00B4E6`, `--vio #8B7BF7`. Frames, rules and glows use those same values, and the type is the IBM Plex Mono the dashboard already ships.

Generating a picture *of* the dashboard would have recreated the exact failure being fixed here — a README showing a UI that doesn't exist — except worse, since it would depict one that never shipped.

## Sized against how GitHub actually renders them

I built these, then previewed them at GitHub's real **896px** README column. Three things were wrong that looked fine at 2752px:

- The hero's numbers were **unreadable** — too much backdrop padding left the dashboard ~470px wide.
- The Exporters image was **~70% empty** — that page has two cards at the top and a large void below.
- Cropping to fix that then **cut the sidebar mid-list**, chopping "Reports" and the active "Exporters" item so it read as a mistake.

Each is now cropped to where its content ends, at 94% of frame width.

## Verification

Every `raw.githubusercontent.com` URL in the README resolves **HTTP 200**. `go test ./...` green.