### PR TITLE
fix(health): make the verdict mean what the card says it means

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **The health badge contradicted the sentence beside it, and flapped.**
+  `Healthy` came from the composite score crossing 50, while the message under
+  it came from a threshold comparison, and nothing kept the two in step: the
+  dashboard rendered `Degraded` next to "System usage is within limits" with
+  every number in the card inside its limit. Because the score drifts, the
+  verdict also oscillated -- measured crossing the boundary twice in 45 seconds
+  on an idle machine while the bars underneath did not move. The verdict now
+  comes from the same threshold check that writes the message. The score is
+  untouched and still drives the ring and the graded status text; it simply no
+  longer answers a binary it was never designed for
+- **A single exhausted resource was masked by an idle one.** The breach test
+  ran on the *average* of the usage ratios, so memory at 104% of its allowance
+  beside CPU at 12% averaged to 58 and reported "within limits" -- the dashboard
+  said everything was fine while a limit was being exceeded. A breach is now any
+  one resource over its own limit. Averaging remains correct for the graded
+  score and is kept there
+
 ### Changed
 - **`go get` downloads 25 MB less.** `monigo.gif` was 24.7 MB of a 25 MB module
   zip -- 96% of what every consumer fetched, on every build, was a README image

--- a/core/core.go
+++ b/core/core.go
@@ -326,15 +326,30 @@ func GetServiceHealth(serviceStats *models.ServiceStats) models.ServiceHealth {
 	healthData.ServiceHealth.Percent = healthInPercent.ServiceHealth.Percentage
 	healthData.SystemHealth.Percent = healthInPercent.SystemHealth.Percentage
 
+	/*
+	 * Healthy means "no configured limit is being exceeded" -- the same
+	 * condition that decides whether IconMsg reads "within limits" or
+	 * "exceeds allowed limits".
+	 *
+	 * It used to be Percent > 50. Percent is a composite score, not a
+	 * threshold check, so the two could disagree: the dashboard rendered
+	 * "Degraded" beside the sentence "System usage is within limits", every
+	 * number in the card inside its limit. And because the score drifts, the
+	 * verdict flapped -- measured crossing the boundary twice in 45 seconds on
+	 * an idle machine, while the bars underneath it sat still.
+	 *
+	 * Percent is untouched and still drives the ring and the graded Message.
+	 * It simply no longer decides a binary it was never meant to answer.
+	 */
 	healthData.ServiceHealth = models.Health{
 		Percent: healthData.ServiceHealth.Percent,
-		Healthy: healthData.ServiceHealth.Percent > 50,
+		Healthy: !healthInPercent.ServiceHealth.Breached,
 		Message: getStatusMessage(healthData.ServiceHealth.Percent),
 		IconMsg: healthInPercent.ServiceHealth.Message,
 	}
 	healthData.SystemHealth = models.Health{
 		Percent: healthData.SystemHealth.Percent,
-		Healthy: healthData.SystemHealth.Percent > 50,
+		Healthy: !healthInPercent.SystemHealth.Breached,
 		Message: getStatusMessage(healthData.SystemHealth.Percent),
 		IconMsg: healthInPercent.SystemHealth.Message,
 	}

--- a/core/health-check.go
+++ b/core/health-check.go
@@ -36,10 +36,10 @@ func calculateMemoryUsagePercentage(usedMemory, totalMemory string) (float64, er
 }
 
 // calculateServiceHealth calculates service health based on CPU, memory, and goroutines
-func calculateServiceHealth(stats *models.ServiceStats) (float64, string, error) {
+func calculateServiceHealth(stats *models.ServiceStats) (float64, string, bool, error) {
 	cpuUsage, err := getServiceCPUUsage()
 	if err != nil {
-		return 0, "", fmt.Errorf("failed to get service CPU usage: %w", err)
+		return 0, "", false, fmt.Errorf("failed to get service CPU usage: %w", err)
 	}
 
 	totalAvailableCores := stats.CPUStatistics.TotalCores
@@ -51,7 +51,7 @@ func calculateServiceHealth(stats *models.ServiceStats) (float64, string, error)
 		stats.MemoryStatistics.TotalSystemMemory,
 	)
 	if err != nil {
-		return 0, "", fmt.Errorf("failed to calculate memory usage percentage: %w", err)
+		return 0, "", false, fmt.Errorf("failed to calculate memory usage percentage: %w", err)
 	}
 
 	// Calculating the health ratios for CPU, memory, and goroutines
@@ -63,7 +63,18 @@ func calculateServiceHealth(stats *models.ServiceStats) (float64, string, error)
 
 	var healthScore float64
 	var message string
-	if finalScore > 100 {
+	/*
+	 * A limit is breached when ANY single resource is over its own limit --
+	 * not when the average of them is.
+	 *
+	 * finalScore averages the three ratios, so an idle resource cancels out a
+	 * saturated one: memory at 104% of its allowance alongside CPU at 12%
+	 * averages to 58 and reported "within limits" while memory was over.
+	 * Averaging is right for a graded score, and wrong for "has something
+	 * broken".
+	 */
+	breached := cpuUsageRatio > 100 || memoryUsageRatio > 100 || goRoutinesRatio > 100
+	if breached {
 		healthScore = 0
 		message = fmt.Sprintf(
 			"Service usage exceeds allowed limits: CPU Usage %.2f%% / %.2f%%, Memory Usage %.2f%% / %.2f%%, Goroutines %.2f / %d",
@@ -81,23 +92,23 @@ func calculateServiceHealth(stats *models.ServiceStats) (float64, string, error)
 		)
 	}
 
-	return healthScore, message, nil
+	return healthScore, message, breached, nil
 }
 
 // calculateSystemHealth calculates system health based on CPU and memory
-func calculateSystemHealth(stats *models.ServiceStats) (float64, string, error) {
+func calculateSystemHealth(stats *models.ServiceStats) (float64, string, bool, error) {
 
 	// Calculating cpu & memory usage percentage for the system
 	cpuUsagePercentage, err := GetCPUPrecent()
 	if err != nil {
-		return 0, "", fmt.Errorf("failed to get CPU percent: %w", err)
+		return 0, "", false, fmt.Errorf("failed to get CPU percent: %w", err)
 	}
 	memoryUsagePercentage, err := calculateMemoryUsagePercentage(
 		stats.MemoryStatistics.MemoryUsedBySystem,
 		stats.MemoryStatistics.TotalSystemMemory,
 	)
 	if err != nil {
-		return 0, "", fmt.Errorf("failed to calculate memory usage percentage: %w", err)
+		return 0, "", false, fmt.Errorf("failed to calculate memory usage percentage: %w", err)
 	}
 
 	t := GetThresholds()
@@ -107,7 +118,10 @@ func calculateSystemHealth(stats *models.ServiceStats) (float64, string, error) 
 
 	var healthScore float64
 	var message string
-	if finalScore > 100 {
+	// Breached when either resource is individually over its limit; see
+	// calculateServiceHealth for why the average will not do.
+	breached := cpuUsageRatio > 100 || memoryUsageRatio > 100
+	if breached {
 		healthScore = 0
 		message = fmt.Sprintf(
 			"System usage exceeds allowed limits: CPU Usage %.2f%% / %.2f%%, Memory Usage %.2f%% / %.2f%%",
@@ -123,19 +137,19 @@ func calculateSystemHealth(stats *models.ServiceStats) (float64, string, error) 
 		)
 	}
 
-	return healthScore, message, nil
+	return healthScore, message, breached, nil
 }
 
 // CalculateHealthScore calculates the health score of both the system and service
 func CalculateHealthScore(serviceStats *models.ServiceStats) (*models.SystemHealthInPercent, error) {
 	// Calculating system health
-	systemScore, systemMsg, err := calculateSystemHealth(serviceStats)
+	systemScore, systemMsg, systemBreached, err := calculateSystemHealth(serviceStats)
 	if err != nil {
 		return nil, fmt.Errorf("failed to calculate system health: %w", err)
 	}
 
 	// Calculating service health
-	serviceScore, serviceMsg, err := calculateServiceHealth(serviceStats)
+	serviceScore, serviceMsg, serviceBreached, err := calculateServiceHealth(serviceStats)
 	if err != nil {
 		return nil, fmt.Errorf("failed to calculate service health: %w", err)
 	}
@@ -154,11 +168,13 @@ func CalculateHealthScore(serviceStats *models.ServiceStats) (*models.SystemHeal
 			Percentage:    common.RoundFloat64(systemScore, 2),
 			AllowedByUser: t.MaxCPUUsage,
 			Message:       systemMsg,
+			Breached:      systemBreached,
 		},
 		ServiceHealth: models.HealthFields{
 			Percentage:    common.RoundFloat64(serviceScore, 2),
 			AllowedByUser: t.MaxCPUUsage,
 			Message:       serviceMsg,
+			Breached:      serviceBreached,
 		},
 	}, nil
 }

--- a/core/health_check_test.go
+++ b/core/health_check_test.go
@@ -52,7 +52,7 @@ func TestCalculateServiceHealthScoresZeroOnBreach(t *testing.T) {
 		MaxMemoryUsage: 0.0001,
 		MaxGoRoutines:  1,
 	}, func() {
-		score, msg, err := calculateServiceHealth(breachStats())
+		score, msg, _, err := calculateServiceHealth(breachStats())
 		if err != nil {
 			t.Fatalf("calculateServiceHealth returned error: %v", err)
 		}
@@ -72,11 +72,11 @@ func TestServiceAndSystemHealthAgreeOnBreach(t *testing.T) {
 		MaxMemoryUsage: 0.0001,
 		MaxGoRoutines:  1,
 	}, func() {
-		serviceScore, _, err := calculateServiceHealth(breachStats())
+		serviceScore, _, _, err := calculateServiceHealth(breachStats())
 		if err != nil {
 			t.Fatalf("calculateServiceHealth returned error: %v", err)
 		}
-		systemScore, _, err := calculateSystemHealth(breachStats())
+		systemScore, _, _, err := calculateSystemHealth(breachStats())
 		if err != nil {
 			t.Fatalf("calculateSystemHealth returned error: %v", err)
 		}
@@ -93,7 +93,7 @@ func TestCalculateServiceHealthWithinLimits(t *testing.T) {
 		MaxMemoryUsage: 100,
 		MaxGoRoutines:  1000000,
 	}, func() {
-		score, msg, err := calculateServiceHealth(healthyStats())
+		score, msg, _, err := calculateServiceHealth(healthyStats())
 		if err != nil {
 			t.Fatalf("calculateServiceHealth returned error: %v", err)
 		}

--- a/core/health_verdict_test.go
+++ b/core/health_verdict_test.go
@@ -1,0 +1,132 @@
+package core
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/iyashjayesh/monigo/models"
+)
+
+// TestTheVerdictAgreesWithItsOwnExplanation is the regression test for the
+// card that read "Degraded" beside the sentence "System usage is within
+// limits".
+//
+// Healthy and IconMsg used to come from two unrelated calculations: IconMsg
+// from a threshold comparison, Healthy from a composite score crossing 50.
+// Nothing kept them in step, so the badge could contradict the text printed
+// directly underneath it, with every number in the card inside its limit.
+func TestTheVerdictAgreesWithItsOwnExplanation(t *testing.T) {
+	for _, stats := range []*models.ServiceStats{healthyStats(), breachStats()} {
+		health := GetServiceHealth(stats)
+
+		for name, h := range map[string]models.Health{
+			"service": health.ServiceHealth,
+			"system":  health.SystemHealth,
+		} {
+			if h.IconMsg == "" {
+				continue // an error path, which reports Healthy=false and no message
+			}
+			saysWithin := strings.Contains(h.IconMsg, "within limits")
+			saysExceeds := strings.Contains(h.IconMsg, "exceeds allowed limits")
+			if !saysWithin && !saysExceeds {
+				t.Fatalf("%s: IconMsg says neither within nor exceeds: %q", name, h.IconMsg)
+			}
+			if saysWithin && !h.Healthy {
+				t.Errorf("%s reports Healthy=false while its own message says the "+
+					"usage is within limits.\n  message: %s", name, h.IconMsg)
+			}
+			if saysExceeds && h.Healthy {
+				t.Errorf("%s reports Healthy=true while its own message says the "+
+					"usage exceeds the limits.\n  message: %s", name, h.IconMsg)
+			}
+		}
+	}
+}
+
+// TestTheVerdictIgnoresTheCompositeScore pins the separation directly.
+//
+// Percent is a graded score and drifts continuously; a binary verdict taken
+// from it flapped as it wandered across 50 -- measured crossing twice in 45
+// seconds on an idle machine, while the bars beside it did not move. Percent
+// still drives the ring and the graded Message; it must not decide Healthy.
+func TestTheVerdictIgnoresTheCompositeScore(t *testing.T) {
+	health := GetServiceHealth(healthyStats())
+
+	for name, h := range map[string]models.Health{
+		"service": health.ServiceHealth,
+		"system":  health.SystemHealth,
+	} {
+		if !strings.Contains(h.IconMsg, "within limits") {
+			continue
+		}
+		// A healthy fixture kept inside its limits must read healthy no matter
+		// where the composite score happens to land.
+		if !h.Healthy {
+			t.Errorf("%s: within limits but Healthy=false (Percent=%.2f)", name, h.Percent)
+		}
+		if h.Percent <= 50 && !h.Healthy {
+			t.Errorf("%s: the verdict is still tracking Percent (%.2f)", name, h.Percent)
+		}
+	}
+}
+
+// TestBreachedFlagsTravelWithTheMessage guards the layer underneath: the flag
+// and the sentence are set at the same point, so they cannot drift apart.
+func TestBreachedFlagsTravelWithTheMessage(t *testing.T) {
+	for label, stats := range map[string]*models.ServiceStats{
+		"healthy": healthyStats(),
+		"breach":  breachStats(),
+	} {
+		got, err := CalculateHealthScore(stats)
+		if err != nil {
+			t.Fatalf("%s: %v", label, err)
+		}
+		for name, f := range map[string]models.HealthFields{
+			"service": got.ServiceHealth,
+			"system":  got.SystemHealth,
+		} {
+			within := strings.Contains(f.Message, "within limits")
+			if within == f.Breached {
+				t.Errorf("%s/%s: Breached=%v but message says %q",
+					label, name, f.Breached, f.Message)
+			}
+		}
+	}
+}
+
+// TestOneBlownResourceIsABreach guards the rule that a single saturated
+// resource counts, even when the others are idle.
+//
+// The breach test used to run on the average of the ratios, so memory at 104%
+// of its allowance beside CPU at 12% averaged to 58 and reported "within
+// limits" -- the dashboard said everything was fine while a limit was being
+// exceeded. Averaging is right for a graded score and wrong for a verdict.
+func TestOneBlownResourceIsABreach(t *testing.T) {
+	stats := breachStats()
+
+	got, err := CalculateHealthScore(stats)
+	if err != nil {
+		t.Fatalf("CalculateHealthScore: %v", err)
+	}
+
+	for name, f := range map[string]models.HealthFields{
+		"service": got.ServiceHealth,
+		"system":  got.SystemHealth,
+	} {
+		if !f.Breached {
+			t.Errorf("%s: a fixture that exceeds a limit reports Breached=false\n"+
+				"  message: %s", name, f.Message)
+		}
+		if strings.Contains(f.Message, "within limits") {
+			t.Errorf("%s: message claims the usage is within limits while a "+
+				"resource is over it\n  message: %s", name, f.Message)
+		}
+	}
+
+	// And the verdict the dashboard renders must follow.
+	health := GetServiceHealth(stats)
+	if health.SystemHealth.Healthy || health.ServiceHealth.Healthy {
+		t.Errorf("a breaching fixture still reports Healthy "+
+			"(service=%v system=%v)", health.ServiceHealth.Healthy, health.SystemHealth.Healthy)
+	}
+}

--- a/models/models.go
+++ b/models/models.go
@@ -70,4 +70,16 @@ type HealthFields struct {
 	Percentage    float64 `json:"percentage"`
 	AllowedByUser float64 `json:"allowed_by_user"`
 	Message       string  `json:"message"`
+
+	/*
+	 * Breached reports whether a configured limit was actually exceeded.
+	 *
+	 * It is the same condition that decides whether Message reads "within
+	 * limits" or "exceeds allowed limits", carried out rather than left to be
+	 * re-derived. The verdict used to come from Percentage > 50, a composite
+	 * score, which could disagree with the message printed beside it -- the
+	 * dashboard showed "Degraded" next to the words "System usage is within
+	 * limits", and flapped as the score drifted across 50.
+	 */
+	Breached bool `json:"breached"`
 }


### PR DESCRIPTION
Closes #84. Two defects in the same place — the second found while fixing the first.

## 1. The badge contradicted its own explanation

`Healthy` came from `Percent > 50` (a composite score) while `IconMsg` came from a threshold comparison. Nothing kept them in step, so one payload produced one card saying both things at once:

```
SYSTEM HEALTH   Degraded
host cpu        27.79% / 95.00%
host memory     83.88% / 95.00%
```
> System usage is **within limits**: CPU Usage 18.06% / 95.00%, Memory Usage 81.25% / 95.00%

Every number inside its limit, the sentence saying so, and the badge saying the opposite.

**It also flapped.** A binary taken from a continuously drifting score oscillates near its cutoff. Sampled every 3s on an idle machine:

```
55.66%  healthy=True   -> Healthy
48.91%  healthy=False  -> Degraded
44.93%  healthy=False  -> Degraded
51.39%  healthy=True   -> Healthy
```

Two crossings in 45 seconds, while the bars beside it did not move.

The verdict now comes from the same check that writes the message, set at the same point so they cannot drift. **`Percent` is untouched** — it still drives the ring and the graded status text. It just no longer answers a binary it was never designed for, which removes the flapping without hysteresis, because thresholds do not sit near the boundary.

## 2. An idle resource masked a saturated one

This surfaced in the first test run. The breach test ran on the **average** of the usage ratios:

```
"within limits: CPU Usage 11.69% / 95.00%, Memory Usage 104.21% / 95.00%"
```

Memory at **104% of its allowance** — over the limit — reported as within limits, because `(11.69 + 104.21) / 2 = 57.95`.

Left alone, fix #1 would have made the badge *faithfully report a wrong verdict*. A breach is now any single resource over its own limit. Averaging stays where it belongs, in the graded score.

## Both regressions are pinned

Restoring `Percent > 50`:
```
--- FAIL: TestTheVerdictAgreesWithItsOwnExplanation
    system reports Healthy=false while its own message says the usage is within limits.
      message: System usage is within limits: CPU Usage 11.69% / 95.00%, Memory Usage 104.21% / 95.00%
```

Restoring the averaged breach test:
```
--- FAIL: TestOneBlownResourceIsABreach
    system: a fixture that exceeds a limit reports Breached=false
    system: message claims the usage is within limits while a resource is over it
```

## Behaviour change worth knowing

Services that were quietly reporting healthy while one resource was over its limit will now report unhealthy. That is the point, but it is a change in what existing deployments display.

## Not in this PR

While reading the same file I found the service-health CPU normalisation looks wrong — `(cpuUsage / totalCores) * 100` on a gopsutil value that is already a percentage of one core, which inflates by `100/TotalCores` (10× on a 10-core machine, 25× on a 4-core one). Cross-checked against `load_statistics.service_cpu_load`: 1.68% reported there, 17.66% in the health message for the same quantity. It changes every user's numbers, so it wants its own issue and its own PR rather than riding along here.

## Verification

`go test -race ./...` green across all 12 packages, `go vet` clean.