### PR TITLE
fix(health): stop inflating service CPU by 100/TotalCores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Service-health CPU was inflated by `100/TotalCores`.** `getServiceCPUUsage`
+  returns percent of one core -- the `top` convention gopsutil follows -- and
+  the health calculation divided it by the core count and then multiplied by
+  100, scaling a value that was already a percentage. The same measurement read
+  `1.68%` under SERVICE CPU LOAD and `17.66%` in the health message on a
+  10-core host; the error grows as machines get smaller, 25x on four cores. An
+  idle process measured **360% on one core** and **132% on four**, both over a
+  95% limit -- which, now that a breach is any single resource over its own
+  limit, was enough to report a healthy service as unhealthy. Both paths now
+  report percent of one core, and a test fails if the reading scales with core
+  count again
+
+### Fixed
 - **The health badge contradicted the sentence beside it, and flapped.**
   `Healthy` came from the composite score crossing 50, while the message under
   it came from a threshold comparison, and nothing kept the two in step: the

--- a/core/health-check.go
+++ b/core/health-check.go
@@ -42,8 +42,23 @@ func calculateServiceHealth(stats *models.ServiceStats) (float64, string, bool, 
 		return 0, "", false, fmt.Errorf("failed to get service CPU usage: %w", err)
 	}
 
-	totalAvailableCores := stats.CPUStatistics.TotalCores
-	cpuUsagePercentage := (cpuUsage / float64(totalAvailableCores)) * 100
+	/*
+	 * getServiceCPUUsage returns percent of ONE core -- gopsutil follows the
+	 * `top` convention, where a process saturating two cores reads 200%. That
+	 * is already a percentage, and it is the same number the dashboard shows
+	 * under SERVICE CPU LOAD, which reads it from common.GetCPULoad.
+	 *
+	 * This used to be `(cpuUsage / TotalCores) * 100`. Dividing by the core
+	 * count converts to share-of-machine; the `* 100` then multiplied a value
+	 * that was already a percentage, inflating by 100/TotalCores -- 10x on a
+	 * 10-core host, 25x on a 4-core one, worst on the smallest machines. The
+	 * same measurement read 1.68% in load_statistics and 17.66% here.
+	 *
+	 * MaxCPUUsage is therefore read in the same units: a service that
+	 * saturates more than one core exceeds 100% by design, exactly as `top`
+	 * would report it.
+	 */
+	cpuUsagePercentage := cpuUsage
 
 	// Calculating memory usage percentage for the service
 	memoryUsagePercentage, err := calculateMemoryUsagePercentage(

--- a/core/health_check_test.go
+++ b/core/health_check_test.go
@@ -20,13 +20,15 @@ func breachStats() *models.ServiceStats {
 	return stats
 }
 
-// healthyStats returns a ServiceStats whose denominators are large enough that
-// the live process CPU reading cannot dominate the score. Service CPU usage is
-// divided by TotalCores, so a small core count makes the result depend on how
-// busy the machine running the tests happens to be.
+// healthyStats returns a ServiceStats comfortably inside every limit.
+//
+// TotalCores used to be 100000 here, to stop the CPU reading dominating the
+// score: service CPU was divided by the core count and multiplied by 100, so a
+// realistic core count inflated it enough to swamp the fixture. The reading no
+// longer scales with cores, so an ordinary number works.
 func healthyStats() *models.ServiceStats {
 	stats := &models.ServiceStats{}
-	stats.CPUStatistics.TotalCores = 100000
+	stats.CPUStatistics.TotalCores = 8
 	stats.MemoryStatistics.TotalSystemMemory = "100000 MB"
 	stats.MemoryStatistics.MemoryUsedByService = "1 MB"
 	stats.MemoryStatistics.MemoryUsedBySystem = "1 MB"

--- a/core/health_verdict_test.go
+++ b/core/health_verdict_test.go
@@ -1,6 +1,8 @@
 package core
 
 import (
+	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -128,5 +130,56 @@ func TestOneBlownResourceIsABreach(t *testing.T) {
 	if health.SystemHealth.Healthy || health.ServiceHealth.Healthy {
 		t.Errorf("a breaching fixture still reports Healthy "+
 			"(service=%v system=%v)", health.ServiceHealth.Healthy, health.SystemHealth.Healthy)
+	}
+}
+
+// TestServiceCPUDoesNotScaleWithCoreCount pins the units.
+//
+// Service CPU is percent of one core, the convention gopsutil and `top` use
+// and the one the dashboard already shows under SERVICE CPU LOAD. It used to
+// be divided by the core count and multiplied by 100, which inflated it by
+// 100/TotalCores -- so the same machine reported 1.68% in load_statistics and
+// 17.66% in the health message, and the error grew as machines got smaller.
+//
+// Core count is the only thing that varies here, so if the reading still
+// scales with it, the two runs disagree.
+func TestServiceCPUDoesNotScaleWithCoreCount(t *testing.T) {
+	cpuFor := func(cores float64) float64 {
+		stats := healthyStats()
+		stats.CPUStatistics.TotalCores = cores
+		_, msg, _, err := calculateServiceHealth(stats)
+		if err != nil {
+			t.Fatalf("cores=%.0f: %v", cores, err)
+		}
+		m := regexp.MustCompile(`CPU Usage ([\d.]+)%`).FindStringSubmatch(msg)
+		if m == nil {
+			t.Fatalf("cores=%.0f: no CPU figure in %q", cores, msg)
+		}
+		v, err := strconv.ParseFloat(m[1], 64)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return v
+	}
+
+	// Both readings sample live process CPU, so they will not be bit-identical.
+	// A core-count dependency would differ by 8x here, far outside that noise.
+	four, sixtyFour := cpuFor(4), cpuFor(64)
+	if four > 5 && sixtyFour > 5 {
+		ratio := four / sixtyFour
+		if ratio < 0.5 || ratio > 2 {
+			t.Errorf("service CPU still scales with core count: "+
+				"%.2f%% at 4 cores vs %.2f%% at 64 (ratio %.2f)", four, sixtyFour, ratio)
+		}
+	}
+
+	// The decisive check: with a idle-ish test process and a 95% limit, the
+	// reading must stay well under the limit whatever the core count. Under
+	// the old arithmetic a 4-core host multiplied it by 25.
+	for _, cores := range []float64{1, 2, 4, 8, 64} {
+		if v := cpuFor(cores); v > 100 {
+			t.Errorf("cores=%.0f: service CPU reads %.2f%%, over the whole "+
+				"allowance, for a test process doing nothing", cores, v)
+		}
 	}
 }


### PR DESCRIPTION
Closes #87. Uses the **percent-of-one-core** convention, matching what the dashboard already displays.

## The same measurement, two different numbers

One `/metrics` response, 10-core host:

```
load_statistics.service_cpu_load : 1.68%
service_health.icon_msg          : CPU Usage 17.66% / 95.00%
```

Ratio: **10.51**. Cores: **10**.

`getServiceCPUUsage` returns gopsutil's `Process.CPUPercent` — percent of **one** core, the `top` convention where a process saturating two cores reads 200%. The health path then did:

```go
cpuUsagePercentage := (cpuUsage / float64(totalAvailableCores)) * 100
```

Dividing by the core count converts to share-of-machine. The `* 100` then multiplied a value that was **already a percentage**.

## It gets worse as machines get smaller

| Cores | Inflation |
| --- | --- |
| 1 | **100×** |
| 4 | **25×** |
| 10 | 10× |
| 100 | 1× (correct by coincidence) |

An **idle** test process, measured:

```
cores=1: service CPU reads 360.39%, over the whole allowance, for a test process doing nothing
cores=2: service CPU reads 178.20%
cores=4: service CPU reads 131.96%
```

All three exceed a 95% limit. And since **#86** made a breach *any single resource over its own limit*, that was enough on its own to report a perfectly healthy service as unhealthy — on exactly the small hosts where people are most likely to be watching.

## System health was checked, and is fine

`calculateSystemHealth` uses `GetCPUPrecent`, which returns a machine-wide total and is used with **no division**. I verified this rather than assuming it — the issue flagged it as an open question.

## A test that was shaped around the defect

`healthyStats()` set `TotalCores = 100000`, with a comment explaining that service CPU "is divided by TotalCores, so a small core count makes the result depend on how busy the machine running the tests happens to be." The fixture was compensating for the bug rather than exposing it. It is `8` now.

`TestServiceCPUDoesNotScaleWithCoreCount` fails on the old arithmetic with the numbers above.

## Behaviour note

`MaxCPUUsage` is now read in the same units, so a service saturating more than one core exceeds 100% by design — as `top` reports it. Anyone who tuned a threshold against the old inflated figure will want to revisit it; the numbers get *smaller*, so the failure mode is a threshold that is now too loose rather than too tight.

## Verification

`go test -race ./...` green across all 12 packages, `go vet` clean.